### PR TITLE
Add Grace.TH module

### DIFF
--- a/grace-core/grace-core.cabal
+++ b/grace-core/grace-core.cabal
@@ -24,6 +24,7 @@ library
                      , prettyprinter-ansi-terminal
                      , scientific
                      , string-interpolate
+                     , template-haskell
                      , terminal-size
                      , text
                      , unordered-containers
@@ -39,6 +40,7 @@ library
                      , Grace.Parser
                      , Grace.Pretty
                      , Grace.Syntax
+                     , Grace.TH
                      , Grace.Type
                      , Grace.Value
   default-language:    Haskell2010

--- a/grace-core/src/Grace/Domain.hs
+++ b/grace-core/src/Grace/Domain.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveLift         #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings  #-}
 
@@ -12,6 +13,7 @@ module Grace.Domain
 
 import GHC.Generics (Generic)
 import Grace.Pretty (Pretty(..), builtin)
+import Language.Haskell.TH.Syntax (Lift)
 
 -- | The domain over which a @forall@ is quantified
 data Domain
@@ -21,7 +23,7 @@ data Domain
     -- ^ @forall (a : Fields) . …@
     | Alternatives
     -- ^ @forall (a : Alternatives) . …@
-    deriving stock (Eq, Generic, Show)
+    deriving stock (Eq, Generic, Lift, Show)
 
 instance Pretty Domain where
     pretty Type         = builtin "Type"

--- a/grace-core/src/Grace/Existential.hs
+++ b/grace-core/src/Grace/Existential.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveLift                 #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
@@ -18,6 +19,7 @@ module Grace.Existential
 
 import Data.Text (Text)
 import Grace.Pretty (Pretty(..), label)
+import Language.Haskell.TH.Syntax (Lift)
 
 import qualified Data.Char as Char
 import qualified Data.Text as Text
@@ -33,6 +35,7 @@ import qualified Data.Text as Text
       variable
 -}
 newtype Existential a = UnsafeExistential Int
+    deriving stock Lift
     deriving newtype (Eq, Num, Show)
 
 instance Pretty (Existential a) where

--- a/grace-core/src/Grace/Monotype.hs
+++ b/grace-core/src/Grace/Monotype.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveLift         #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings  #-}
 
@@ -20,6 +21,7 @@ import Data.Text (Text)
 import GHC.Generics (Generic)
 import Grace.Existential (Existential)
 import Grace.Pretty (Pretty(..), builtin)
+import Language.Haskell.TH.Syntax (Lift)
 
 {-| A monomorphic type
 
@@ -72,7 +74,7 @@ data Scalar
     --
     -- >>> pretty Text
     -- Text
-    deriving stock (Eq, Generic, Show)
+    deriving stock (Eq, Generic, Lift, Show)
 
 instance Pretty Scalar where
     pretty Bool    = builtin "Bool"
@@ -99,7 +101,7 @@ data RemainingFields
     | VariableFields Text
     -- ^ Same as `UnsolvedFields`, except that the user has given the fields
     --   variable an explicit name in the source code
-    deriving stock (Eq, Generic, Show)
+    deriving stock (Eq, Generic, Lift, Show)
 
 -- | A monomorphic union type
 data Union = Alternatives [(Text, Monotype)] RemainingAlternatives
@@ -118,4 +120,4 @@ data RemainingAlternatives
     | VariableAlternatives Text
     -- ^ Same as `UnsolvedAlternatives`, except that the user has given the
     --   alternatives variable an explicit name in the source code
-    deriving stock (Eq, Generic, Show)
+    deriving stock (Eq, Generic, Lift, Show)

--- a/grace-core/src/Grace/Syntax.hs
+++ b/grace-core/src/Grace/Syntax.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ApplicativeDo      #-}
 {-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveLift         #-}
 {-# LANGUAGE DeriveTraversable  #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances  #-}
@@ -31,6 +32,7 @@ import Data.String (IsString(..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Grace.Type (Type)
+import Language.Haskell.TH.Syntax (Lift)
 import Numeric.Natural (Natural)
 import Prettyprinter (Doc)
 import Prettyprinter.Render.Terminal (AnsiStyle)
@@ -60,7 +62,7 @@ import qualified Prettyprinter as Pretty
 
 -- | The surface syntax for the language
 data Syntax s a = Syntax { location :: s, node :: Node s a }
-    deriving stock (Eq, Foldable, Functor, Generic, Show, Traversable)
+    deriving stock (Eq, Foldable, Functor, Generic, Lift, Show, Traversable)
 
 instance Bifunctor Syntax where
     first f Syntax{ location, node } =
@@ -197,7 +199,7 @@ data Node s a
     --   x + y
     | Builtin Builtin
     | Embed a
-    deriving stock (Eq, Foldable, Generic, Functor, Show, Traversable)
+    deriving stock (Eq, Foldable, Functor, Generic, Lift, Show, Traversable)
 
 instance Bifunctor Node where
     first _ (Variable name index) =
@@ -269,7 +271,7 @@ data Scalar
     -- ^
     --   >>> pretty Null
     --   null
-    deriving (Eq, Generic, Show)
+    deriving (Eq, Generic, Lift, Show)
 
 instance Pretty Scalar where
     pretty (Bool True )     = scalar "true"
@@ -298,7 +300,7 @@ data Operator
     -- ^
     --   >>> pretty Times
     --   *
-    deriving (Eq, Generic, Show)
+    deriving (Eq, Generic, Lift, Show)
 
 instance Pretty Operator where
     pretty And    = operator "&&"
@@ -392,7 +394,7 @@ data Builtin
     -- ^
     --   >>> pretty TextEqual
     --   Text/equal
-    deriving (Bounded, Enum, Eq, Generic, Show)
+    deriving (Bounded, Enum, Eq, Generic, Lift, Show)
 
 instance Pretty Builtin where
     pretty RealEqual      = builtin "Real/equal"
@@ -728,7 +730,7 @@ data Binding s a = Binding
     , name :: Text
     , annotation :: Maybe (Type s)
     , assignment :: Syntax s a
-    } deriving stock (Eq, Foldable, Functor, Generic, Show, Traversable)
+    } deriving stock (Eq, Foldable, Functor, Generic, Lift, Show, Traversable)
 
 instance Bifunctor Binding where
     first f Binding{ nameLocation, annotation, assignment, .. } =

--- a/grace-core/src/Grace/TH.hs
+++ b/grace-core/src/Grace/TH.hs
@@ -1,0 +1,104 @@
+module Grace.TH
+    ( grace
+
+      -- * Embedding an expression
+    , expressionFromCode
+    , expressionFromFile
+    , expressionFromInput
+
+      -- * Embedding the type of an expression
+    , typeOfCode
+    , typeOfFile
+    , typeOfInput
+    ) where
+
+import Data.Functor (void)
+import Data.Text (Text)
+import Data.Void (Void)
+import Grace.Interpret (Input(..))
+import Grace.Syntax (Syntax)
+import Grace.Type (Type)
+import Language.Haskell.TH.Quote (QuasiQuoter(..))
+import Language.Haskell.TH.Syntax (Lift, Q, TExp(..))
+
+import qualified Control.Monad.Except as Except
+import qualified Data.Text            as Text
+import qualified Grace.Interpret      as Interpret
+import qualified Grace.Normalize      as Normalize
+import qualified Language.Haskell.TH  as TH
+import qualified Language.Haskell.TH.Syntax as TH
+
+-- $setup
+-- >>> :set -XOverloadedStrings -XQuasiQuotes -XTemplateHaskell
+
+{- | A quasi-quoter for expressions.
+
+     Takes the source code of a expression, type checks it and returns the fully
+     normalized AST.
+
+     >>> [grace| "hello" |]
+     Syntax {location = (), node = Scalar (Text "hello")}
+
+     This quoter is implemented using `expressionFromCode`.
+     Note that other quoting (declarations, patterns, types) is not supported.
+-}
+grace :: QuasiQuoter
+grace = QuasiQuoter
+    { quoteExp = fmap TH.unType . expressionFromCode . Text.pack
+    , quoteDec = error "Declaration quoting not supported !"
+    , quotePat = error "Pattern quoting not supported !"
+    , quoteType = error "Type quoting not supported !"
+    }
+
+{- | Evaluate an expression at compile time.
+
+     This function takes the source code of a expressions, type checks it and
+     returns the fully normalized AST.
+
+     >>> $$(expressionFromCode "\"hello\"")
+     Syntax {location = (), node = Scalar (Text "hello")}
+-}
+expressionFromCode :: Text -> Q (TExp (Syntax () Void))
+expressionFromCode = expressionFromInput . Code
+
+-- | Like `expressionFromCode`, but takes path of a source file as input.
+expressionFromFile :: FilePath -> Q (TExp (Syntax () Void))
+expressionFromFile = expressionFromInput . Path
+
+-- | Like `expressionFromCode`, but expects `Input` as an argument.
+expressionFromInput :: Input -> Q (TExp (Syntax () Void))
+expressionFromInput = helperFunction snd
+
+{- | Infer the type of an expression at compile time.
+
+     This function takes the source code of an expressions, type checks it and
+     returns the inferred type of that expression.
+
+     >>> $$(typeOfCode "\"hello\"")
+     Type {location = (), node = Scalar Text}
+-}
+typeOfCode :: Text -> Q (TExp (Type ()))
+typeOfCode = typeOfInput . Code
+
+-- | Like `typeOfCode`, but takes path of a source file as input.
+typeOfFile :: FilePath -> Q (TExp (Type ()))
+typeOfFile = typeOfInput . Path
+
+-- | Like `typeOfCode`, but expects `Input` as an argument.
+typeOfInput :: Input -> Q (TExp (Type ()))
+typeOfInput = helperFunction fst
+
+-- Internal functions
+
+helperFunction :: Lift r => ((Type (), Syntax () Void) -> r) -> Input -> Q (TExp r)
+helperFunction f input = do
+    eitherResult <- Except.runExceptT $ Interpret.interpret Nothing input
+
+    (inferred, value) <- case eitherResult of
+        Left e -> fail $ Text.unpack e
+        Right result -> return result
+
+    let type_ = void inferred
+        syntax = Normalize.quote [] value
+
+    TExp <$> TH.lift (f (type_, syntax))

--- a/grace-core/src/Grace/TH.hs
+++ b/grace-core/src/Grace/TH.hs
@@ -45,9 +45,9 @@ import qualified Language.Haskell.TH.Syntax as TH
 grace :: QuasiQuoter
 grace = QuasiQuoter
     { quoteExp = fmap TH.unType . expressionFromCode . Text.pack
-    , quoteDec = error "Declaration quoting not supported !"
-    , quotePat = error "Pattern quoting not supported !"
-    , quoteType = error "Type quoting not supported !"
+    , quoteDec = error "Declaration quoting not supported"
+    , quotePat = error "Pattern quoting not supported"
+    , quoteType = error "Type quoting not supported"
     }
 
 {- | Evaluate an expression at compile time.

--- a/grace-core/src/Grace/Type.hs
+++ b/grace-core/src/Grace/Type.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ApplicativeDo      #-}
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveLift         #-}
 {-# LANGUAGE DeriveTraversable  #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances  #-}
@@ -46,6 +47,7 @@ import GHC.Generics (Generic)
 import Grace.Domain (Domain)
 import Grace.Existential (Existential)
 import Grace.Pretty (Pretty(..), keyword, punctuation, label, builtin, operator)
+import Language.Haskell.TH.Syntax (Lift)
 import Prettyprinter (Doc)
 import Prettyprinter.Render.Terminal (AnsiStyle)
 
@@ -71,7 +73,7 @@ import qualified Prettyprinter  as Pretty
 
 -- | A potentially polymorphic type
 data Type s = Type { location :: s, node :: Node s }
-    deriving stock (Eq, Functor, Generic, Show)
+    deriving stock (Eq, Functor, Generic, Lift, Show)
 
 instance IsString (Type ()) where
     fromString string = Type{ location = (), node = fromString string }
@@ -180,7 +182,7 @@ data Node s
     -- >>> pretty @(Node ()) (Union (Alternatives [("x", "X"), ("y", "Y")] (Monotype.UnsolvedAlternatives 0)))
     -- < x: X | y: Y | a? >
     | Scalar Scalar
-    deriving stock (Eq, Functor, Generic, Show)
+    deriving stock (Eq, Functor, Generic, Lift, Show)
 
 instance IsString (Node s) where
     fromString string = VariableType (fromString string)
@@ -190,14 +192,14 @@ instance Pretty (Node s) where
 
 -- | A potentially polymorphic record type
 data Record s = Fields [(Text, Type s)] RemainingFields
-    deriving stock (Eq, Functor, Generic, Show)
+    deriving stock (Eq, Functor, Generic, Lift, Show)
 
 instance Pretty (Record s) where
     pretty = prettyRecordType
 
 -- | A potentially polymorphic union type
 data Union s = Alternatives [(Text, Type s)] RemainingAlternatives
-    deriving stock (Eq, Functor, Generic, Show)
+    deriving stock (Eq, Functor, Generic, Lift, Show)
 
 instance Pretty (Union s) where
     pretty = prettyUnionType


### PR DESCRIPTION
This PR adds the `Grace.TH` module containing

- a `grace` quasi-quoter.
- several Template Haskell functions that allow you to embed the AST or the type of an expression at compile time.