### PR TITLE
Add `:help` and `:quit` commands to the REPL

### DIFF
--- a/src/Grace/Repl.hs
+++ b/src/Grace/Repl.hs
@@ -120,7 +120,7 @@ repl = do
             [ ("help", Repline.dontCrash . help)
             , ("let", Repline.dontCrash . assignment)
             -- `paste` is included here for auto-completion purposes only.
-            -- `repline`'s `multilineCommand` logic overrides this `mempty`.
+            -- `repline`'s `multilineCommand` logic overrides this no-op.
             , ("paste", Repline.dontCrash . \_ -> return ())
             , ("quit", quit)
             , ("type", Repline.dontCrash . infer)

--- a/src/Grace/Repl.hs
+++ b/src/Grace/Repl.hs
@@ -119,7 +119,7 @@ repl = do
     let options =
             [ ("help", Repline.dontCrash . help)
             , ("let", Repline.dontCrash . assignment)
-            , ("paste", Repline.dontCrash . \_ -> return ())
+            , ("paste", Repline.dontCrash . mempty)
             , ("quit", quit)
             , ("type", Repline.dontCrash . infer)
             ]

--- a/src/Grace/Repl.hs
+++ b/src/Grace/Repl.hs
@@ -12,7 +12,7 @@ module Grace.Repl
     ) where
 
 import Control.Applicative (empty)
-import Control.Exception.Safe (displayException)
+import Control.Exception.Safe (displayException, throwIO)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State (MonadState(..))
 import Data.Foldable (toList)
@@ -20,6 +20,7 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.String.Interpolate (__i)
 import Grace.Interpret (Input(..))
 import Grace.Lexer (reserved)
+import System.Console.Haskeline (Interrupt(..))
 import System.Console.Repline (CompleterStyle(..), MultiLine(..), ReplOpts(..))
 
 import qualified Control.Monad as Monad
@@ -76,6 +77,8 @@ repl = do
                     Infer the type of an expression
                 :let IDENTIFIER = EXPRESSION
                     Assign an expression to a variable
+                :quit
+                    Exit the REPL
             |])
 
     let assignment string
@@ -110,10 +113,14 @@ repl = do
 
                     liftIO (Pretty.renderIO True width IO.stdout (Pretty.pretty type_ <> "\n"))
 
+    let quit _ =
+            liftIO (throwIO Interrupt)
+
     let options =
             [ ("help", Repline.dontCrash . help)
             , ("let", Repline.dontCrash . assignment)
             , ("paste", Repline.dontCrash . \_ -> return ())
+            , ("quit", quit)
             , ("type", Repline.dontCrash . infer)
             ]
 

--- a/src/Grace/Repl.hs
+++ b/src/Grace/Repl.hs
@@ -97,6 +97,7 @@ repl = do
 
     let options =
             [ ("let", Repline.dontCrash . assignment)
+            , ("paste", Repline.dontCrash . \_ -> return ())
             , ("type", Repline.dontCrash . infer)
             ]
 

--- a/src/Grace/Repl.hs
+++ b/src/Grace/Repl.hs
@@ -121,7 +121,7 @@ repl = do
             , ("let", Repline.dontCrash . assignment)
             -- `paste` is included here for auto-completion purposes only.
             -- `repline`'s `multilineCommand` logic overrides this `mempty`.
-            , ("paste", Repline.dontCrash . mempty)
+            , ("paste", Repline.dontCrash . \_ -> return ())
             , ("quit", quit)
             , ("type", Repline.dontCrash . infer)
             ]

--- a/src/Grace/Repl.hs
+++ b/src/Grace/Repl.hs
@@ -119,6 +119,8 @@ repl = do
     let options =
             [ ("help", Repline.dontCrash . help)
             , ("let", Repline.dontCrash . assignment)
+            -- `paste` is included here for auto-completion purposes only.
+            -- `repline`'s `multilineCommand` logic overrides this `mempty`.
             , ("paste", Repline.dontCrash . mempty)
             , ("quit", quit)
             , ("type", Repline.dontCrash . infer)


### PR DESCRIPTION
First thing I did while poking around `grace` was boot up the REPL. And the first thing I tried to do in the REPL was run `:help`, but no dice 🙃 I think the `:help` command is useful for getting a grip on the REPL, and by extension the language.

No hard feelings if you'd rather not merge this 👍 