### PR TITLE
Move tutorial examples out of `try-grace/Main.hs`

### DIFF
--- a/examples/tutorial/checkboxes.ffg
+++ b/examples/tutorial/checkboxes.ffg
@@ -1,0 +1,7 @@
+# This Grace browser attempts to faithfully render any Grace expression
+# as an equivalent HTML representation.  For example, a list of boolean
+# values such as these will render as an HTML list of checkboxes:
+
+[ true, false, true ]
+
+# Try adding another false value to the above list.

--- a/examples/tutorial/coding.ffg
+++ b/examples/tutorial/coding.ffg
@@ -1,0 +1,14 @@
+\arguments ->
+
+let key = arguments."OpenAI key" in
+
+# What do you think this code will do?  Run it to test your guess:
+prompt{ key, code: true }
+    : { jobDescription: Text } -> { isFinance : Bool, rationale : Text }
+# You can read the above type as "a function whose input is a record (with a
+# `jobDescription` field) and whose output is a record (with `isFinance` and
+# `rationale` fields)
+
+# The `code: true` argument instructs the model to generate Grace code matching
+# the expected type.  The generated Grace might use the `prompt` keyword, too!
+# Be sure to check out the "Code" tab to see what code the model generated

--- a/examples/tutorial/data.ffg
+++ b/examples/tutorial/data.ffg
@@ -1,0 +1,31 @@
+# A record will render as a definition list when converted to HTML
+
+{ "An example string": "Mercury"
+, "An example string with a type annotation": "cosmic" : Text
+, "A boolean value": true
+, "Annotated boolean value": false : Bool
+, "A natural number": 42
+, "An integer": -12
+, "A real number": 3.14159265359
+, "A list of natural numbers": [ 1, 1, 2, 3, 5, 8, 13 ]
+, "Annotated list of natural numbers": [ 1, 1, 2, 3, 5, 8, 13 ] : List Natural
+, "Annotated record": { x: 0, y: 0 } : { x: Natural, y: Natural }
+, "A list of records (using JSON syntax with quoted field names)":
+    [ { "isActive": true
+      , "age": 36
+      , "name": "Dunlap Hubbard"
+      , "email": "dunlaphubbard@example.com"
+      , "phone": "+1 (555) 543-2508"
+      }
+    , { "isActive": true
+      , "age": 24
+      , "name": "Kirsten Sellers"
+      , "email": "kirstensellers@example.com"
+      , "phone": "+1 (555) 564-2190"
+      }
+    ]
+}
+
+# What type do you think the last field has?  Switch to the "Type" tab below
+# to check your guess, then switch back to the "Form" tab before proceeding to
+# the next example.

--- a/examples/tutorial/functions.ffg
+++ b/examples/tutorial/functions.ffg
@@ -1,0 +1,34 @@
+# You can also define functions using `let` expressions:
+let greet{ name } = "Hello, ${name}!"
+
+let greeting = greet{ name: "world" }
+
+# You can add optional type annotations to a function's arguments and output:
+let greet{ name: Text } : Text = "Hello, ${name}!"
+# The type of the `greet` function is `{ name: Text } -> Text` which you can
+# read as "a function whose input is a record (with a `name` field) and whose
+# output is `Text`
+
+# Function definitions can define intermediate variables:
+let makeUser{ user } =
+        let home = "/home/${user}"
+        let privateKey = "${home}/.ssh/id_ed25519"
+        let publicKey = "${privateKey}.pub"
+        in  { home, privateKey, publicKey }
+# What do you think the type of the `makeUser` function is?  Check the "Type"
+# tab below to check your guess.
+
+let users =
+        [ makeUser{ user: "bill" }
+        , makeUser{ user: "jane" }
+        ]
+
+# We include the functions we defined (i.e. `greet` and `makeUser`) in the
+# output because the Grace browser can render functions as interactive forms.
+# Switch back to the "Form" tab and try entering your name into the generated
+# interactive forms.
+in  { greet
+    , greeting
+    , makeUser
+    , users
+    }

--- a/examples/tutorial/hello.ffg
+++ b/examples/tutorial/hello.ffg
@@ -1,0 +1,12 @@
+# This is a tour of the Fall-from-Grace language (a.k.a. "Grace" for short).
+#
+# First, any line prefixed with a "#" character is a comment, like this one.
+#
+# Second, any change you make to this editable code area will show up below.
+# Try editing the string "Hello, world!" below to replace "world" with your
+# name.
+#
+# Once you are done, click on the "HTML" tab above to proceed to the next
+# example.
+
+"Hello, world!"

--- a/examples/tutorial/imports.ffg
+++ b/examples/tutorial/imports.ffg
@@ -1,0 +1,10 @@
+# You can reference other Grace expressions by their URL.  For example,
+# the following URL encodes a function for computing US federal income
+# tax for 2022:
+https://gist.githubusercontent.com/Gabriella439/712d0648bbdcfcc83eadd0ee394beed3/raw/694198a2d114278c42e4981ed6af67b8e3229cea/incomeTax.ffg
+# You can use this feature to create reusable Grace code.
+#
+# Grace browser sessions are sharable, too!  If you copy your current tab's URL
+# and open that URL in a new tab you will get the same Grace browser session.
+# This means that all forms you create within the Grace browser are
+# automatically sharable, too.

--- a/examples/tutorial/lists.ffg
+++ b/examples/tutorial/lists.ffg
@@ -1,0 +1,33 @@
+# Now let's cover the basic list operations.
+
+let somePrimes = [ 2, 3, 5, 7, 11 ]
+
+# You can access list elements using dot notation.  `x.n` returns the
+# (0-indexed) nth element of the list:
+let two = somePrimes.0
+let three = somePrimes.1
+
+# Just like Python, negative numbers index from the end of the list:
+let eleven = somePrimes.-1
+let seven = somePrimes.-2
+
+# Use `list[i:j]` to return a slice from the list.
+#
+# The lower bound (i) is inclusive and the upperbound (j) is not inclusive:
+let middleThreeElements = somePrimes[1:4]
+
+# You can omit the lower bound to begin from the first element:
+let firstThreeElements = somePrimes[:3]
+
+# You can omit the upper bound to end on the last element:
+let lastThreeElements = somePrimes[-3:]
+
+in  { somePrimes
+    , two
+    , three
+    , eleven
+    , seven
+    , middleThreeElements
+    , firstThreeElements
+    , lastThreeElements
+    }

--- a/examples/tutorial/prelude.ffg
+++ b/examples/tutorial/prelude.ffg
@@ -1,0 +1,16 @@
+# Grace also has a Prelude of utility functions derived from built-in
+# functions that you can also use.
+
+# You can import functions individually, like this:
+let not = https://raw.githubusercontent.com/Gabriella439/grace/main/prelude/bool/not.ffg
+
+# You can also import the Prelude as a whole, which is a nested record:
+let prelude = https://raw.githubusercontent.com/Gabriella439/grace/main/prelude/package.ffg
+
+# Then you can access functions as record fields:
+let clamp = prelude.integer.clamp
+
+in  { "not": not
+    , "clamp": clamp
+    , "The entire Prelude": prelude
+    }

--- a/examples/tutorial/prompting.ffg
+++ b/examples/tutorial/prompting.ffg
@@ -1,0 +1,30 @@
+# Grace provides built-in language support for LLMs using the `prompt` function.
+# To run these examples you will need to provide an OpenAI API key below and.
+# and then click "Submit".
+\arguments ->
+
+let key = arguments."OpenAI key" in
+
+{ # You can prompt a model with `Text`, which will (by default) return `Text`:
+  names: prompt{ key, text: "Give me a list of names" }
+
+, # You can request structured output with a type annotation, like this:
+  structuredNames: prompt{ key, text: "Give me a list of names" } : List Text
+
+, # If you request a record with first and last name fields then the model will
+  # adjust its output to match:
+  fullNames:
+    prompt{ key, text: "Give me a list of names" }
+      : List { firstName: Text, lastName: Text }
+
+, # In fact, that type is descriptive enough that we can just omit the prompt:
+  tacitFullNames: prompt{ key } : List { firstName: Text, lastName: Text }
+
+, # By default the `prompt` keyword selects the `o4-mini` model, but you can
+  # specify other models using the `model` argument:
+  differentModel:
+    prompt{ key, model: "gpt-4o" } : List { firstName: Text, lastName: Text }
+}
+
+# Try switching to the "Code" tab below to view the code for the result, then
+# switch back to the "Form" tab and continue to the next example.

--- a/examples/tutorial/variables.ffg
+++ b/examples/tutorial/variables.ffg
@@ -1,0 +1,14 @@
+# You can define a variable using `let`:
+let john = { name: "John Doe", age: 24 }
+
+# Variables can reference earlier variables:
+let twentyFour = john.age
+
+# You can nest `let` expressions:
+let nine = let three = 3
+           in  three * three
+
+in  nine * twentyFour
+# Grace is whitespace-insensitive (with the exception of comments, which extend
+# to the next newline character), so try deleting all of the above comments and
+# modifying the above code to fit on one line.

--- a/grace.cabal
+++ b/grace.cabal
@@ -133,6 +133,7 @@ executable try-grace
                      , async
                      , commonmark
                      , containers
+                     , filepath
                      , ghcjs-base
                      , grace
                      , insert-ordered-containers


### PR DESCRIPTION
Now that we have the `Grace.DataFile` module, we can store the tutorial examples as static assets on the server.

Factoring them out in this way makes them easier to edit.