### PR TITLE
Fix the inferred type of a slice

### DIFF
--- a/src/Grace/Infer.hs
+++ b/src/Grace/Infer.hs
@@ -1960,11 +1960,13 @@ infer e₀ = do
 
                     let element = Type.UnsolvedType{ location, existential }
 
-                    let listType = Type.List{ location, type_ = element }
+                    let list = Type.List{ location, type_ = element }
 
-                    newLarger <- check larger listType
+                    let optional = Type.Optional{ location, type_ = list }
 
-                    return (listType, Syntax.Project{ location, larger = newLarger, .. })
+                    newLarger <- check larger list
+
+                    return (optional, Syntax.Project{ location, larger = newLarger, .. })
 
         Syntax.If{..} -> do
             newPredicate <- check predicate Type.Scalar{ scalar = Monotype.Bool, .. }

--- a/tasty/data/complex/slice-type.ffg
+++ b/tasty/data/complex/slice-type.ffg
@@ -1,26 +1,26 @@
 forall (a : Type) .
   { "slicing an empty list always return null":
-      List a
+      Optional (List a)
   , "otherwise, [:] returns the entire list":
-      List Natural
+      Optional (List Natural)
   , "[:] is equivalent to [0:0]":
-      List Natural
+      Optional (List Natural)
   , "[n:n] returns the entire list starting and ending at element n":
-      List Natural
+      Optional (List Natural)
   , "[m:n] returns the mth element up to and not including the mth element":
-      List Natural
+      Optional (List Natural)
   , "[n:] drops the first n elements of the list":
-      List Natural
+      Optional (List Natural)
   , "[n:] is equivalent to [n:0]":
-      List Natural
+      Optional (List Natural)
   , "[:-n] drops the last n elements of the list":
-      List Natural
+      Optional (List Natural)
   , "[:n] is equivalent to [0:n]":
-      List Natural
+      Optional (List Natural)
   , "slice indices do not need to be in order":
-      List Natural
+      Optional (List Natural)
   , "both slice indices can be negative":
-      List Natural
+      Optional (List Natural)
   , "both slice indices can be past the end of the list":
-      List Natural
+      Optional (List Natural)
   }

--- a/tasty/data/error/type/index-slice-input.ffg
+++ b/tasty/data/error/type/index-slice-input.ffg
@@ -1,0 +1,2 @@
+# This should fail because a slice returns an `Optional`
+[{ }][0:].0

--- a/tasty/data/error/type/index-slice-stderr.txt
+++ b/tasty/data/error/type/index-slice-stderr.txt
@@ -1,0 +1,19 @@
+Not a subtype
+
+The following type:
+
+  Optional (List { })
+
+tasty/data/error/type/index-slice-input.ffg:2:1: 
+  │
+2 │ [{ }][0:].0
+  │ ↑
+
+… cannot be a subtype of:
+
+  List a?
+
+tasty/data/error/type/index-slice-input.ffg:2:1: 
+  │
+2 │ [{ }][0:].0
+  │ ↑

--- a/tasty/data/unit/slice-type.ffg
+++ b/tasty/data/unit/slice-type.ffg
@@ -1,1 +1,1 @@
-List Natural
+Optional (List Natural)


### PR DESCRIPTION
Fixes https://github.com/Gabriella439/grace/issues/104

A slice returns an `Optional (List …)` and not a `List`.  This fixes the inferred type of slice to match the normalization logic, preventing a normalization failure that would otherwise happen if the result were treated like an ordinary (non-`Optional`) `List`.