### PR TITLE
Fix `nix run .#docker-stream`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -253,10 +253,18 @@
               website = ghcjs.website;
             };
 
-            apps.default = {
-              type = "app";
+            apps = {
+              default = {
+                type = "app";
 
-              program = nixpkgs.lib.getExe self.packages."${system}".default;
+                program = nixpkgs.lib.getExe self.packages."${system}".default;
+              };
+
+              docker-stream = {
+                type = "app";
+
+                program = "${self.packages."${system}".docker-stream}";
+              };
             };
 
             devShells = {


### PR DESCRIPTION
Before this change it would attempt to run
`/nix/store/…-stream-grace/bin/stream-grace`, when the correct thing to do is to run `/nix/store/…-stream-grace/` (which this change fixes).