### PR TITLE
Add support for dynamic imports without schemas

### DIFF
--- a/grace.cabal
+++ b/grace.cabal
@@ -85,6 +85,7 @@ library
                      , DeriveTraversable
                      , DerivingStrategies
                      , DuplicateRecordFields
+                     , FlexibleContexts
                      , GeneralizedNewtypeDeriving
                      , MultiWayIf
                      , NamedFieldPuns

--- a/src/Grace.hs
+++ b/src/Grace.hs
@@ -11,6 +11,7 @@ import Control.Exception.Safe (Exception(..), SomeException)
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Void (Void)
+import Grace.Infer (Status(..))
 import Grace.Input (Input(..), Mode(..))
 import Grace.Location (Location(..))
 import Grace.Syntax (Builtin(..), Syntax(..))
@@ -20,6 +21,7 @@ import Prettyprinter (Doc)
 import Prettyprinter.Render.Terminal (AnsiStyle)
 
 import qualified Control.Exception.Safe as Exception
+import qualified Control.Monad.State as State
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text.IO
 import qualified GHC.IO.Encoding
@@ -220,7 +222,9 @@ main = Exception.handle handler do
 
             let expected = Type.Scalar{ scalar = Monotype.Text, location }
 
-            (_, value) <- Interpret.interpretWith keyToMethods [] (Just expected) input
+            let initialStatus = Status{ count = 0, input, context = [] }
+
+            (_, value) <- State.evalStateT (Interpret.interpretWith keyToMethods [] (Just expected) input) initialStatus
 
             case value of
                 Value.Text text -> Text.IO.putStr text

--- a/src/Grace/GitHub.hs
+++ b/src/Grace/GitHub.hs
@@ -46,6 +46,7 @@ github import_ GitHub{ key, owner, repository, reference, path } = do
 
     let headers = Just
             (   [ Header{ header = "X-GitHub-Api-Version", value = "2022-11-28" }
+                , Header{ header = "User-Agent", value = "Grace" }
                 ]
             <>  authorization
             )

--- a/src/Grace/Infer.hs-boot
+++ b/src/Grace/Infer.hs-boot
@@ -1,0 +1,18 @@
+module Grace.Infer where
+
+import Grace.Context (Context)
+import Grace.Input (Input)
+import Grace.Location (Location)
+
+-- | Type-checking state
+data Status = Status
+    { count :: !Int
+      -- ^ Used to generate fresh unsolved variables (e.g. α̂, β̂ from the
+      --   original paper)
+
+    , context :: Context Location
+      -- ^ The type-checking context (e.g. Γ, Δ, Θ)
+
+    , input :: Input
+      -- ^ The parent import, used to resolve relative imports
+    }

--- a/src/Grace/Interpret.hs
+++ b/src/Grace/Interpret.hs
@@ -11,21 +11,25 @@ module Grace.Interpret
 
 import Control.Exception.Safe (MonadCatch)
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.State (MonadState)
 import Data.Text (Text)
 import Grace.Decode (FromGrace(..))
 import Grace.HTTP (Methods)
+import Grace.Infer (Status(..))
 import Grace.Input (Input(..))
 import Grace.Location (Location(..))
 import Grace.Type (Type)
 import Grace.Value (Value)
 
 import qualified Control.Exception.Safe as Exception
+import qualified Control.Monad.State as State
 import qualified Grace.Context as Context
 import qualified Grace.HTTP as HTTP
 import qualified Grace.Import as Import
 import qualified Grace.Infer as Infer
 import qualified Grace.Normalize as Normalize
 import qualified Grace.Syntax as Syntax
+import qualified Grace.Value as Value
 
 {-| Interpret Grace source code, return the inferred type and the evaluated
     result
@@ -36,11 +40,16 @@ interpret
     :: (MonadCatch m, MonadIO m)
     => (Text -> Methods) -> Input -> m (Type Location, Value)
 interpret keyToMethods input = do
-    interpretWith keyToMethods [] Nothing input
+    let initialStatus = Status{ count = 0, input, context = [] }
+
+    ((inferred, value), Status{ context }) <- do
+        State.runStateT (interpretWith keyToMethods [] Nothing input) initialStatus
+
+    return (Context.complete context inferred, Value.complete context value)
 
 -- | Like `interpret`, but accepts a custom list of bindings
 interpretWith
-    :: (MonadCatch m, MonadIO m)
+    :: (MonadCatch m, MonadState Status m, MonadIO m)
     => (Text -> Methods)
     -- ^ OpenAI methods
     -> [(Text, Type Location, Value)]
@@ -67,14 +76,16 @@ interpretWith keyToMethods bindings maybeAnnotation input = do
 
             return (Context.Annotation variable type_)
 
-    (inferred, elaboratedExpression) <- Infer.typeWith input typeContext annotatedExpression
+    State.modify (\status -> status{ context = typeContext <> context status })
+
+    (inferred, elaboratedExpression) <- Infer.infer annotatedExpression
 
     let evaluationContext = do
             (variable, _, value) <- bindings
 
             return (variable, value)
 
-    value <- liftIO (Normalize.evaluate keyToMethods evaluationContext elaboratedExpression)
+    value <- Normalize.evaluate keyToMethods evaluationContext elaboratedExpression
 
     return (inferred, value)
 
@@ -85,7 +96,9 @@ load input = do
 
     let type_ = fmap (\_ -> Unknown) (expected @a)
 
-    (_, value) <- interpretWith keyToMethods [] (Just type_) input
+    let initialStatus = Status{ count = 0, input, context = [] }
+
+    (_, value) <- State.evalStateT (interpretWith keyToMethods [] (Just type_) input) initialStatus
 
     case decode value of
         Left exception -> Exception.throwM exception

--- a/src/Grace/Interpret.hs-boot
+++ b/src/Grace/Interpret.hs-boot
@@ -4,6 +4,7 @@ module Grace.Interpret where
 
 import Control.Exception.Safe (MonadCatch)
 import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.State (MonadState)
 import Data.Text (Text)
 import Grace.HTTP (Methods)
 import Grace.Input (Input(..))
@@ -11,8 +12,11 @@ import Grace.Location (Location(..))
 import Grace.Type (Type)
 import Grace.Value (Value)
 
+import {-# SOURCE #-} Grace.Infer (Status)
+
+-- | Like `interpret`, but accepts a custom list of bindings
 interpretWith
-    :: (MonadCatch m, MonadIO m)
+    :: (MonadCatch m, MonadState Status m, MonadIO m)
     => (Text -> Methods)
     -- ^ OpenAI methods
     -> [(Text, Type Location, Value)]
@@ -21,3 +25,4 @@ interpretWith
     -- ^ Optional expected type for the input
     -> Input
     -> m (Type Location, Value)
+

--- a/src/Grace/REPL.hs
+++ b/src/Grace/REPL.hs
@@ -15,6 +15,7 @@ import Data.Foldable (toList)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Text (Text)
 import Grace.HTTP (Methods)
+import Grace.Infer (Status(..))
 import Grace.Interpret (Input(..))
 import Grace.Parser (reserved)
 import System.Console.Haskeline (Interrupt(..))
@@ -25,10 +26,12 @@ import qualified Control.Monad as Monad
 import qualified Control.Monad.State as State
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text.IO
+import qualified Grace.Context as Context
 import qualified Grace.Interpret as Interpret
 import qualified Grace.Normalize as Normalize
 import qualified Grace.Pretty as Pretty
 import qualified Grace.Type as Type
+import qualified Grace.Value as Value
 import qualified Grace.Width as Width
 import qualified System.Console.Haskeline.Completion as Completion
 import qualified System.Console.Repline as Repline
@@ -41,9 +44,11 @@ repl keyToMethods = do
             liftIO (Text.IO.hPutStrLn IO.stderr (Text.pack (displayException e)))
 
     let interpret input = do
-            context <- get
+            bindings <- get
 
-            Exception.try @_ @SomeException (Interpret.interpretWith keyToMethods context Nothing input)
+            let initialStatus = Status{ count = 0, input, context = [] }
+
+            Exception.try @_ @SomeException (State.runStateT (Interpret.interpretWith keyToMethods bindings Nothing input) initialStatus)
 
     let command string = do
             let input = Code "(input)" (Text.pack string)
@@ -54,8 +59,10 @@ repl keyToMethods = do
                 Left e -> do
                     err e
 
-                Right (_inferred, value) -> do
-                    let syntax = Normalize.strip (Normalize.quote value)
+                Right ((_inferred, value), Status{ context })  -> do
+                    let completed = Value.complete context value
+
+                    let syntax = Normalize.strip (Normalize.quote completed)
 
                     width <- liftIO Width.getWidth
 
@@ -87,8 +94,10 @@ repl keyToMethods = do
                     Left e -> do
                         err e
 
-                    Right (type_, value) -> do
-                        State.modify ((variable, type_, value) :)
+                    Right ((type_, value), Status{ context }) -> do
+                        let completed = Value.complete context value
+
+                        State.modify ((variable, type_, completed) :)
 
             | otherwise = do
                 liftIO (putStrLn "usage: let = {expression}")
@@ -102,10 +111,12 @@ repl keyToMethods = do
                 Left e -> do
                     err e
 
-                Right (type_, _) -> do
+                Right ((type_, _), Status{ context })  -> do
+                    let completed = Context.complete context type_
+
                     width <- liftIO Width.getWidth
 
-                    liftIO (Pretty.renderIO True width IO.stdout (Pretty.pretty type_ <> "\n"))
+                    liftIO (Pretty.renderIO True width IO.stdout (Pretty.pretty completed <> "\n"))
 
     let quit _ =
             liftIO (throwIO Interrupt)

--- a/src/Grace/Syntax.hs
+++ b/src/Grace/Syntax.hs
@@ -10,10 +10,11 @@ module Grace.Syntax
       Syntax(..)
     , usedIn
     , effects
+    , types
+    , complete
     , Chunks(..)
     , Field(..)
     , Smaller(..)
-    , types
     , Scalar(..)
     , Operator(..)
     , Builtin(..)
@@ -34,6 +35,7 @@ import Data.String (IsString(..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Grace.Compat ()  -- For an orphan instance for Lift (Seq a)
+import Grace.Context (Context)
 import Grace.Pretty (Pretty(..), keyword, punctuation)
 import Grace.Type (Type)
 import Language.Haskell.TH.Syntax (Lift)
@@ -59,6 +61,7 @@ import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
 import qualified Data.Aeson as Aeson
 import qualified Data.Text as Text
+import qualified Grace.Context as Context
 import qualified Grace.Pretty as Pretty
 import qualified Grace.Type as Type
 import qualified Prettyprinter as Pretty
@@ -627,14 +630,14 @@ usedIn _ Builtin{ } =
 usedIn _ Embed{ } =
     False
 
--- | Matches all effects within a `Syntax` tree
+-- | `Getting` that matches all effects within a `Syntax` tree
 effects :: Getting Any (Syntax s a) ()
-effects =
-      Lens.cosmos
-    . (   (_As @"Prompt" . Lens.to (\_ -> ()))
-      <>  (_As @"HTTP"   . Lens.to (\_ -> ()))
-      <>  (_As @"GitHub" . Lens.to (\_ -> ()))
-      )
+effects = Lens.cosmos . effect
+  where
+    effect =
+            (_As @"Prompt" . Lens.to (\_ -> ()))
+        <>  (_As @"HTTP"   . Lens.to (\_ -> ()))
+        <>  (_As @"GitHub" . Lens.to (\_ -> ()))
 
 -- | A text literal with interpolated expressions
 data Chunks s a = Chunks Text [(Syntax s a, Text)]
@@ -712,7 +715,7 @@ data Smaller s
 instance IsString (Smaller ()) where
     fromString string = Single{ single = fromString string }
 
--- | @Traversal'@ from a `Syntax` to its immediate `Type` annotations
+-- | @Traversal'@ from a `Syntax` to its immediate `Type`
 types :: Traversal' (Syntax s a) (Type s)
 types onType
     Lambda{ location, nameBinding = NameBinding{ nameLocation, name, annotation, assignment }, body } = do
@@ -794,8 +797,12 @@ types onType Let{ location, bindings, body } = do
                 , annotation = newAnnotation
                 , assignment
                 }
-
 types _ e = pure e
+
+-- | Complete all `Type` annotations in a `Syntax` tree using the provided
+-- `Context`
+complete :: Context s -> Syntax s a -> Syntax s a
+complete context = Lens.transform (Lens.over types (Context.complete context))
 
 -- | A scalar value
 data Scalar

--- a/try-grace/Main.hs
+++ b/try-grace/Main.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE BlockArguments      #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE MultiWayIf          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE BlockArguments        #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE MultiWayIf            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
 
 module Main where
 
@@ -20,16 +21,16 @@ import Data.JSString (JSString)
 import Data.Sequence (ViewR(..), (|>))
 import Data.Text (Text)
 import Data.Traversable (forM)
+import Grace.Infer (Status(..))
 import Grace.Type (Type(..))
 import GHCJS.Foreign.Callback (Callback)
 import GHCJS.Types (JSVal)
 import Grace.Decode (FromGrace)
-import Grace.Domain (Domain(..))
 import Grace.Encode (ToGrace(..))
 import Grace.HTTP (Methods)
 import Grace.Input (Input(..))
 import Grace.Location (Location)
-import Grace.Monotype (RemainingAlternatives(..), RemainingFields(..))
+import Grace.Monotype (RemainingFields(..))
 import Grace.Syntax (Scalar(..))
 import Grace.Value (Value(..))
 import JavaScript.Array (JSArray)
@@ -59,6 +60,7 @@ import qualified Data.Text.Lazy as Text.Lazy
 import qualified Data.Text.Lazy.Encoding as Text.Encoding
 import qualified GHCJS.Foreign.Callback as Callback
 import qualified GHCJS.Types
+import qualified Grace.Context as Context
 import qualified Grace.DataFile as DataFile
 import qualified Grace.Decode as Decode
 import qualified Grace.HTTP as HTTP
@@ -388,34 +390,19 @@ renderValue
     :: (Text -> Methods)
     -> IORef Natural
     -> JSVal
+    -> Status
     -> Type Location
     -> Value
     -> IO (IO ())
-renderValue keyToMethods ref parent Type.Forall{ name, nameLocation, domain = Type, type_ } value = do
-    -- If an expression has a polymorphic type, specialize the type to Text
-    let text = Type.Scalar{ location = nameLocation, scalar = Monotype.Text }
+renderValue keyToMethods ref parent status Type.Optional{ type_ } value =
+    renderValue keyToMethods ref parent status type_ value
 
-    renderValue keyToMethods ref parent (Type.substituteType name 0 text type_) value
-
-renderValue keyToMethods ref parent Type.Forall{ name, domain = Fields, type_ } value = do
-    let empty_ = Type.Fields [] EmptyFields
-
-    renderValue keyToMethods ref parent (Type.substituteFields name 0 empty_ type_) value
-
-renderValue keyToMethods ref parent Type.Forall{ name, domain = Alternatives, type_ } value = do
-    let empty_ = Type.Alternatives [] EmptyAlternatives
-
-    renderValue keyToMethods ref parent (Type.substituteAlternatives name 0 empty_ type_) value
-
-renderValue keyToMethods ref parent Type.Optional{ type_ } value =
-    renderValue keyToMethods ref parent type_ value
-
-renderValue _ _ parent _ (Value.Text text) = do
+renderValue _ _ parent _ _ (Value.Text text) = do
     setInnerHTML parent (markdownToHTML text)
 
     mempty
 
-renderValue _ _ parent _ (Value.Scalar (Bool bool)) = do
+renderValue _ _ parent _ _ (Value.Scalar (Bool bool)) = do
     input <- createElement "input"
 
     setAttribute input "type"     "checkbox"
@@ -428,7 +415,7 @@ renderValue _ _ parent _ (Value.Scalar (Bool bool)) = do
 
     mempty
 
-renderValue _ _ parent _ (Value.Scalar Null) = do
+renderValue _ _ parent _ _ (Value.Scalar Null) = do
     span <- createElement "span"
 
     setAttribute span "class" "fira"
@@ -439,7 +426,7 @@ renderValue _ _ parent _ (Value.Scalar Null) = do
 
     mempty
 
-renderValue _ _ parent _ value@Value.Scalar{} = do
+renderValue _ _ parent _ _ value@Value.Scalar{} = do
     span <- createElement "span"
 
     setTextContent span (valueToText value)
@@ -451,7 +438,7 @@ renderValue _ _ parent _ value@Value.Scalar{} = do
 
     mempty
 
-renderValue keyToMethods ref parent outer (Value.List values) = do
+renderValue keyToMethods ref parent status outer (Value.List values) = do
     inner <- case outer of
             Type.List{ type_ } -> do
                 return type_
@@ -465,7 +452,7 @@ renderValue keyToMethods ref parent outer (Value.List values) = do
     results <- forM values \value -> do
         li <- createElement "li"
 
-        refreshOutput <- renderValue keyToMethods ref li inner value
+        refreshOutput <- renderValue keyToMethods ref li status inner value
 
         return (li, refreshOutput)
 
@@ -479,7 +466,7 @@ renderValue keyToMethods ref parent outer (Value.List values) = do
 
     return (sequence_ refreshOutputs)
 
-renderValue keyToMethods ref parent outer (Value.Record keyValues) = do
+renderValue keyToMethods ref parent status outer (Value.Record keyValues) = do
     let lookupKey = case outer of
             Type.Record{ fields = Type.Fields keyTypes _ } ->
                 \key -> lookup key keyTypes
@@ -511,7 +498,7 @@ renderValue keyToMethods ref parent outer (Value.Record keyValues) = do
 
             setAttribute dd "class" "col"
 
-            refreshOutput <- renderValue keyToMethods ref dd type_ value
+            refreshOutput <- renderValue keyToMethods ref dd status type_ value
 
             dl <- createElement "dl"
 
@@ -529,10 +516,10 @@ renderValue keyToMethods ref parent outer (Value.Record keyValues) = do
 
     return (sequence_ refreshOutputs)
 
-renderValue keyToMethods ref parent outer (Application (Value.Builtin Syntax.Some) value) = do
-    renderValue keyToMethods ref parent outer value
+renderValue keyToMethods ref parent status outer (Application (Value.Builtin Syntax.Some) value) = do
+    renderValue keyToMethods ref parent status outer value
 
-renderValue keyToMethods ref parent outer (Value.Alternative alternative value) = do
+renderValue keyToMethods ref parent status outer (Value.Alternative alternative value) = do
     inner <- case outer of
             Type.Union{ alternatives = Type.Alternatives keyTypes _ } ->
                 case lookup alternative keyTypes of
@@ -550,9 +537,9 @@ renderValue keyToMethods ref parent outer (Value.Alternative alternative value) 
 
     let recordValue = Value.Record (HashMap.singleton alternative value)
 
-    renderValue keyToMethods ref parent recordType recordValue
+    renderValue keyToMethods ref parent status recordType recordValue
 
-renderValue keyToMethods counter parent Type.Function{ input, output } function = do
+renderValue keyToMethods counter parent status Type.Function{ input, output } function = do
     outputVal <- createElement "div"
 
     (setBusy, setSuccess, setError) <- createForm False outputVal
@@ -560,13 +547,19 @@ renderValue keyToMethods counter parent Type.Function{ input, output } function 
     let render value = do
             setBusy
 
-            eitherResult <- (liftIO . Exception.try) do
-                newValue <- Normalize.apply keyToMethods function value
+            let interpretOutput = do
+                    newValue <- Normalize.apply keyToMethods function value
 
-                refreshOutput <- setSuccess output newValue \htmlWrapper -> do
-                    renderValue keyToMethods counter htmlWrapper output newValue
+                    status_@Status{ context } <- State.get
 
-                refreshOutput
+                    let solvedType = Context.solveType context output
+
+                    refreshOutput <- liftIO $ setSuccess solvedType newValue \htmlWrapper -> do
+                        renderValue keyToMethods counter htmlWrapper status_ solvedType newValue
+
+                    liftIO refreshOutput
+
+            eitherResult <- liftIO (Exception.try (State.evalStateT interpretOutput status))
 
             case eitherResult of
                 Left exception -> do
@@ -577,26 +570,29 @@ renderValue keyToMethods counter parent Type.Function{ input, output } function 
 
     debouncedRender <- debounce render
 
-    if Lens.has Value.effects function
-        then do
-            (_, reader) <- renderInput [] input
+    (_, reader) <- renderInput [] input
 
-            let renderOutput Submit = debouncedRender
-                renderOutput Change = mempty
+    let hasEffects = Lens.has Value.effects function
 
-            result <- Maybe.runMaybeT (Reader.runReaderT reader RenderInput
-                { keyToMethods
-                , renderOutput
-                , counter
-                })
+    let renderOutput Change | hasEffects = mempty
+        renderOutput _                   = debouncedRender
 
-            case result of
-                Nothing -> do
-                    replaceChildren parent (Array.fromList [ ])
+    result <- Maybe.runMaybeT (Reader.runReaderT reader RenderInput
+        { keyToMethods
+        , renderOutput
+        , counter
+        , status
+        })
 
-                    mempty
+    case result of
+        Nothing -> do
+            replaceChildren parent (Array.fromList [ ])
 
-                Just (inputVal, invoke, refreshOutput) -> do
+            mempty
+
+        Just (inputVal, invoke, refreshOutput) -> do
+            if hasEffects
+                then do
                     button <- createElement "button"
 
                     setAttribute button "type"  "button"
@@ -612,38 +608,19 @@ renderValue keyToMethods counter parent Type.Function{ input, output } function 
 
                     replaceChildren parent (Array.fromList [ inputVal, button, hr, outputVal ])
 
-                    return refreshOutput
-
-        else do
-            (_, reader) <- renderInput [] input
-
-            let renderOutput _ = debouncedRender
-
-            result <- Maybe.runMaybeT (Reader.runReaderT reader RenderInput
-                { keyToMethods
-                , renderOutput
-                , counter
-                })
-
-            case result of
-                Nothing -> do
-                    replaceChildren parent (Array.fromList [ ])
-
-                    mempty
-
-                Just (inputVal, invoke, refreshOutput) -> do
+                else do
                     invoke Submit
 
                     hr <- createElement "hr"
 
                     replaceChildren parent (Array.fromList [ inputVal, hr, outputVal ])
-                    return refreshOutput
+            return refreshOutput
 
 -- At the time of this writing this case should (in theory) never be hit,
 -- because all of the `Value` constructors are either explicitly handled (e.g.
 -- `Text` / `Scalar`) or handled by the case for `Type.Function` (e.g. `Builtin`
 -- / `Alternative`)
-renderValue _ _ parent _ value = do
+renderValue _ _ parent _ _ value = do
     renderDefault parent value
 
 renderDefault :: JSVal -> Value -> IO (IO ())
@@ -666,6 +643,7 @@ data RenderInput = RenderInput
     { keyToMethods :: Text -> Methods
     , renderOutput :: Mode -> Value -> IO ()
     , counter :: IORef Natural
+    , status :: Status
     }
 
 register
@@ -1365,7 +1343,7 @@ renderInputDefault path type_ = do
             Nothing -> ""
 
     return $ (,) (Value.Scalar Null) do
-        RenderInput{ keyToMethods, renderOutput } <- Reader.ask
+        RenderInput{ keyToMethods, renderOutput, status } <- Reader.ask
 
         textarea <- createElement "textarea"
 
@@ -1390,10 +1368,12 @@ renderInputDefault path type_ = do
 
                 let input_ = Code "(input)" text
 
-                result <- (liftIO . Exception.try) do
-                    (_, value) <- Interpret.interpretWith keyToMethods [] (Just type_) input_
+                let interpretInput = do
+                        (_, value) <- Interpret.interpretWith keyToMethods [] (Just type_) input_
 
-                    return value
+                        return value
+
+                result <- liftIO (Exception.try (State.evalStateT interpretInput status))
 
                 case result of
                     Left exception -> do
@@ -1661,17 +1641,29 @@ main = do
 
                     let input_ = Code "(input)" text
 
-                    result <- Exception.try do
-                        expression <- Import.resolve input_
+                    let initialStatus = Status
+                            { count = 0
+                            , input = input_
+                            , context = []
+                            }
 
-                        (inferred, elaboratedExpression) <- Infer.typeWith input_ [] expression
+                    let interpretOutput = do
+                            expression <- liftIO (Import.resolve input_)
 
-                        value <- Normalize.evaluate keyToMethods [] elaboratedExpression
+                            (inferred, elaboratedExpression) <- Infer.infer expression
 
-                        refreshOutput <- setSuccess inferred value \htmlWrapper -> do
-                            renderValue keyToMethods counter htmlWrapper inferred value
+                            value <- Normalize.evaluate keyToMethods [] elaboratedExpression
 
-                        refreshOutput
+                            status@Status{ context } <- State.get
+
+                            let solvedType = Context.solveType context inferred
+
+                            refreshOutput <- liftIO $ setSuccess solvedType value \htmlWrapper -> do
+                                renderValue keyToMethods counter htmlWrapper status solvedType value
+
+                            liftIO refreshOutput
+
+                    result <- Exception.try (State.evalStateT interpretOutput initialStatus)
 
 
                     case result of


### PR DESCRIPTION
This is a pretty massive change so that the user can omit the schema when importing an expression dynamically (e.g.
`import {prompt,http,read,github}`).

The biggest change associated with this is to thread type-checking state throughout the entire interpretation process (not just during type-checking).  In particular, this threads the type-checking state throughout evaluation so that the evaluator can update unsolved variables in response to the dynamic import's result.

As a concrete example, consider the following Grace expression:

```haskell
let f = import prompt{ key, text: "increment the input" } in { f, x: f 0 }
```

What would normally happen (before this change) is that the above example would fail because it would infer an unsolved variable as the in the `prompt`'s type:

```haskell
{ f : Natural -> a?, x: a? }
```

… and if you try a whole bunch of "obvious" solutions they fail on the above example

The only solution that works reliably is to not complete the unsolved variables until evaluation is done.  This means that every time we compute a dynamic import we preserve the type-checking state exactly as it was (which might include a partially solved type with unsolved variables) and update any unsolved variables in response to the imported type.

Using the above example, now Grace will tell the LLM to generate an expression of type `Natural -> a?` that increments the input, the LLM will return `\n -> n + 1`, and then `a?` will be solved to `Natural`, and the final inferred type of the entire expression will be `{ f: Natural -> Natural, x: Natural }`.

This also implies that evaluation can no longer be automatically parallelized (since two sub-expressions which might have dynamic imports can't update the type-checking context in parallels).  This could be partially restored by parallelizing code that doesn't update type-checking state but to simplify things I just removed parallelization from the evaluator.