### PR TITLE
Add support for GitHub short-links

### DIFF
--- a/examples/chaining.ffg
+++ b/examples/chaining.ffg
@@ -1,4 +1,6 @@
-\{ key } ->
+\{ "OpenAI API key" } ->
+
+let key = .'OpenAI API key'
 
 let question = prompt
         { key

--- a/examples/code.ffg
+++ b/examples/code.ffg
@@ -1,3 +1,5 @@
-\{ key } ->
+\{ "OpenAI API key" } ->
 
-import prompt{ key, text: "Uppercase the input" } "abc" : Text
+let key = .'OpenAI API key'
+
+in  import prompt{ key, text: "Uppercase the input" } "abc" : Text

--- a/examples/poem.ffg
+++ b/examples/poem.ffg
@@ -1,4 +1,6 @@
-\{ key } ->
+\{ "OpenAI API key" } ->
+
+let key = .'OpenAI API key'
 
 let concatSep =
       https://raw.githubusercontent.com/Gabriella439/grace/refs/heads/main/prelude/text/concatSep.ffg

--- a/examples/prompt.ffg
+++ b/examples/prompt.ffg
@@ -1,3 +1,7 @@
-let numbers = prompt{ text: "Give me two numbers" }
+\{ "OpenAI API key" } ->
+
+let key = .'OpenAI API key'
+
+let numbers = prompt{ key, text: "Give me two numbers" }
 
 in  { x: numbers.x, y: numbers.y, sum: numbers.x + numbers.y : Integer }

--- a/examples/tools.ffg
+++ b/examples/tools.ffg
@@ -1,4 +1,6 @@
-\{ key } ->
+\{ "OpenAI API key" } ->
+
+let key = .'OpenAI API key'
 
 let concatSep = https://raw.githubusercontent.com/Gabriella439/grace/refs/heads/main/prelude/text/concatSep.ffg
 

--- a/examples/tutorial/coding.ffg
+++ b/examples/tutorial/coding.ffg
@@ -1,6 +1,6 @@
 \arguments ->
 
-let key = arguments."OpenAI key" in
+let key = arguments."OpenAI API key" in
 
 # What do you think this code will do?  Run it to test your guess:
 import prompt{ key }

--- a/examples/tutorial/prompting.ffg
+++ b/examples/tutorial/prompting.ffg
@@ -3,7 +3,7 @@
 # and then click "Submit".
 \arguments ->
 
-let key = arguments."OpenAI key" in
+let key = arguments."OpenAI API key" in
 
 { # You can prompt a model with `Text`, which will (by default) return `Text`:
   names: prompt{ key, text: "Give me a list of names" }

--- a/src/Grace/GitHub.hs
+++ b/src/Grace/GitHub.hs
@@ -9,6 +9,7 @@ import Data.Aeson (FromJSON)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Grace.Decode (FromGrace(..), Key(..))
+import Grace.Encode (ToGrace)
 import Grace.HTTP.Type (Header(..), HTTP(..), Parameter(..))
 
 import qualified Data.Text as Text
@@ -23,7 +24,7 @@ data GitHub = GitHub
     , repository :: Text
     , path :: Text
     } deriving stock (Generic)
-      deriving anyclass (FromGrace)
+      deriving anyclass (FromGrace, ToGrace)
 
 -- | Response from GitHub @\/repos/${owner}\/${repo}\/contents\/${path}@ API
 data Contents = Contents{ download_url :: Text }

--- a/src/Grace/Syntax.hs
+++ b/src/Grace/Syntax.hs
@@ -1314,7 +1314,7 @@ prettyApplicationExpression expression
         prefix = if import_ then keyword "import" <> " " else mempty
     prettyLong GitHub{ import_, arguments } =
             prefix
-        <>  keyword "read"
+        <>  keyword "github"
         <>  Pretty.hardline
         <>  "  "
         <>  Pretty.nest 2 (prettyProjectExpression arguments)


### PR DESCRIPTION
You can now link to Grace code hosted on GitHub easily by linking to `trygrace.dev?github=${owner}/${repository}/${path}` and optionally add `&reference=${ref}` or `&private=true` if you want to provide an API key to access a private repository.