### PR TITLE
Remove duplicate HTTP request for `import github`

### DIFF
--- a/src/Grace/GitHub.hs
+++ b/src/Grace/GitHub.hs
@@ -31,14 +31,14 @@ data Contents = Contents{ download_url :: Text }
     deriving stock (Generic)
     deriving anyclass (FromJSON)
 
-{-| Make an HTTP request to GitHub
+{-| Get the download URL of a file on GitHub
 
     This is an ergonomic convenience for the user for the exceedingly common use
     case of fetching code in version control from GitHub (and also powers
     trygrace.dev's `/github/${owner}/${repository}/${path}` short-links.
 -}
-github :: Bool -> GitHub -> IO (Text, Text)
-github import_ GitHub{ key, owner, repository, reference, path } = do
+github :: GitHub -> IO Text
+github GitHub{ key, owner, repository, reference, path } = do
     let authorization = case key of
             Nothing ->
                 [ ]
@@ -65,10 +65,4 @@ github import_ GitHub{ key, owner, repository, reference, path } = do
 
     Contents{ download_url } <- Grace.Aeson.decode contentsResponse
 
-    contents <- HTTP.http import_ GET
-        { url = download_url
-        , headers = Nothing
-        , parameters = Nothing
-        }
-
-    return (contents, download_url)
+    return download_url

--- a/src/Grace/Normalize.hs
+++ b/src/Grace/Normalize.hs
@@ -27,7 +27,7 @@ import Data.Text (Text)
 import Data.Void (Void)
 import Grace.Aeson (JSONDecodingFailed(..))
 import Grace.Decode (FromGrace(..))
-import Grace.HTTP (Methods)
+import Grace.HTTP (HTTP(..), Methods)
 import Grace.Infer (Status(..))
 import Grace.Input (Input(..), Mode(..))
 import Grace.Location (Location(..))
@@ -396,7 +396,7 @@ evaluate keyToMethods env₀ syntax₀ = do
                     Left exception -> Exception.throwIO exception
                     Right http -> return http
 
-                (responseBody, url) <- liftIO (GitHub.github import_ github)
+                url <- liftIO (GitHub.github github)
 
                 if import_
                     then do
@@ -417,6 +417,12 @@ evaluate keyToMethods env₀ syntax₀ = do
                         return value
 
                     else do
+                        responseBody <- liftIO $ HTTP.http import_ GET
+                            { url = url
+                            , headers = Nothing
+                            , parameters = Nothing
+                            }
+
                         aesonValue <- liftIO (Grace.Aeson.decode responseBody)
 
                         let defaultedSchema =


### PR DESCRIPTION
The change in #143 introduced a duplicate HTTP request when using `import github` because first `GitHub.github` would make an HTTP request for the file (which would then be discarded) and then `Interpret.interpretWith` would make another HTTP request for the same file (because the `download_url` would be provided as the `input`), which would be kept and used.

This change fixes `GitHub.github` to no longer perform the `http` request at all.  Instead, it now just returns the `download_url` and then if it is an `import` that will be passed to `Interpret.interpretWith` as the `input` which will handle the HTTP request.  If it is not an `import` then the non-`import` code path will now handle the `http` request itself (the same as the original `GitHub.github` code).