### PR TITLE
Add "Copy" and "Print" buttons to trygrace.dev text outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -152,9 +152,9 @@
                   self.lib.fold self.lib.composeExtensions oldOverrides
                     (   [ sourceOverrides
                           directoryOverrides
-                          manualOverrides
                         ]
                     ++  self.lib.optional (compiler == "ghcjs") ghcjsOverrides
+                    ++  [ manualOverrides ]
                     );
             });
           };

--- a/website/css/grace.css
+++ b/website/css/grace.css
@@ -63,3 +63,21 @@ textarea {
 #start-tutorial, #stop-tutorial, #api-key {
   margin-bottom: 1em;
 }
+
+.printable {
+  margin-right: 10em;
+}
+
+.print-button {
+  position: absolute;
+  top: 0.5em;
+  right: 0.5em;
+  cursor: pointer;
+}
+
+.copy-button {
+  position: absolute;
+  top: 0.5em;
+  right: 5em;
+  cursor: pointer;
+}

--- a/website/index.html
+++ b/website/index.html
@@ -43,6 +43,50 @@ function autoResize(element) {
     element.style.height = element.scrollHeight + 'px';
   });
 }
+function print(element) {
+  const printWindow = window.open('', '_blank');
+
+  printWindow.document.write(`
+    <html>
+      <head>
+        <title>Preview</title>
+        <style>
+          @media print {
+            @page {
+              size: Letter portrait;
+
+              margin: 0em;
+            }
+          }
+
+          .printable {
+            margin: 0.5in !important;
+          }
+
+          ${
+          Array.from(document.styleSheets).map(styleSheet =>
+            Array.from(styleSheet.cssRules).map(cssRule =>
+              cssRule.cssText
+            ).join('\n')
+          ).join('\n')
+          }
+        </style>
+      </head>
+      <body>
+        <div class="printable">
+          ${element.outerHTML}
+        </div>
+        <script>
+          window.onload = function() {
+            window.onafterprint = function() { window.close(); };
+
+            window.print();
+          }
+        <\/script>
+      <\/body>
+    <\/html>
+  `);
+}
 </script>
 <script defer language="javascript" src="js/all.js"></script>
 </html>


### PR DESCRIPTION
Now all `Text` values include an unobtrusive "Copy" button (which copies the text to the clipboard) and "Print" button (which opens a new printable preview tab of the element's contents).  The latter doubles as a convenient way to export the text field's contents to a PDF.