### PR TITLE
try-grace.dev: Use `Context.complete` for displayed types

### DIFF
--- a/try-grace/Main.hs
+++ b/try-grace/Main.hs
@@ -603,9 +603,11 @@ renderValue parent Type.Function{ input, output } function = do
 
                     status_@Status{ context } <- State.get
 
+                    let completedType = Context.complete context output
+
                     let solvedType = Context.solveType context output
 
-                    refreshOutput <- liftIO $ setSuccess solvedType newValue \htmlWrapper -> do
+                    refreshOutput <- liftIO $ setSuccess completedType newValue \htmlWrapper -> do
                         Reader.runReaderT (renderValue htmlWrapper solvedType newValue) (r :: RenderValue){ status = status_ }
 
                     liftIO refreshOutput
@@ -1710,9 +1712,12 @@ main = do
 
                             status@Status{ context } <- State.get
 
+                            let completedType =
+                                    Context.complete context inferred
+
                             let solvedType = Context.solveType context inferred
 
-                            refreshOutput <- liftIO $ setSuccess solvedType value \htmlWrapper -> do
+                            refreshOutput <- liftIO $ setSuccess completedType value \htmlWrapper -> do
                                 Reader.runReaderT (renderValue htmlWrapper solvedType value) RenderValue{ keyToMethods, counter, status, edit }
 
                             liftIO refreshOutput


### PR DESCRIPTION
Even though we use `Context.solveType` under the hood, we should be using `Context.complete` for types displayed to the user since those are easier on the eyes (even if they are a white lie)