### PR TITLE
Keep ./ when parsing file paths

### DIFF
--- a/src/Grace/Parser.hs
+++ b/src/Grace/Parser.hs
@@ -246,7 +246,7 @@ lexDotNumber = try do
 
 lexFile :: Lexer Token
 lexFile = (lexeme . try) do
-    prefix <- ("../" <|> ("" <$ "./") <|> "/") Megaparsec.<?> "path character"
+    prefix <- ("../" <|> "./" <|> "/") Megaparsec.<?> "path character"
 
     let isPath c =
                  '\x21' == c


### PR DESCRIPTION
Not sure if this won't have some undesirable consequences, but it fixes the issue of `grace format` removing these slashes, leading to invalid programs.