### PR TITLE
Fix test failures related to relative paths

### DIFF
--- a/src/Grace/Input.hs
+++ b/src/Grace/Input.hs
@@ -10,6 +10,7 @@ import Data.Text (Text)
 import Grace.Pretty (Pretty(..))
 import System.FilePath ((</>))
 
+import qualified Data.List as List
 import qualified Data.Text as Text
 import qualified Grace.Pretty as Pretty
 import qualified System.FilePath as FilePath
@@ -44,8 +45,12 @@ instance Semigroup Input where
         | otherwise =
             Path child mode
       where
+        stripped = case List.stripPrefix "./" child of
+            Nothing     -> child
+            Just suffix -> suffix
+
         uriPath = do
-            c : cs <- traverse (URI.mkPathPiece . Text.pack) (FilePath.splitPath child)
+            c : cs <- traverse (URI.mkPathPiece . Text.pack) (FilePath.splitPath stripped)
 
             return (FilePath.hasTrailingPathSeparator child, c :| cs)
 

--- a/tasty/Main.hs
+++ b/tasty/Main.hs
@@ -164,7 +164,7 @@ interpretCodeWithImport = Tasty.HUnit.testCase "interpret code with import from 
     let expectedValue =
             (Type.Scalar{ location, scalar = Monotype.Natural }, Value.Scalar (Syntax.Natural 5))
           where
-            location = Location{ name = "tasty/data/unit/plus-input.ffg", code = "2 + 3\n", offset = 2 }
+            location = Location{ name = "./tasty/data/unit/plus-input.ffg", code = "2 + 3\n", offset = 2 }
 
     Tasty.HUnit.assertEqual "" expectedValue actualValue
 


### PR DESCRIPTION
Apparently CI is not running tests (probably my fault) and I will look into that, but in the meantime I discovered that because tests were not being run that two small test failures slipped through, which this change fixes.

The most important fix is to strip `./` from relative paths before making them relative to a URI.  The leading `./` was restored in #158 and just needed a matching change the `Semigroup` instance for `Input`.