### PR TITLE
Limit retries on openai createChatCompletion endpoint

### DIFF
--- a/ghc/Grace/HTTP.hs
+++ b/ghc/Grace/HTTP.hs
@@ -77,7 +77,7 @@ retry io =
         ]
         (\_ -> io)
   where
-    retryPolicy = Retry.fullJitterBackoff 1000000
+    retryPolicy = Retry.fullJitterBackoff 1000000 <> Retry.limitRetries 3
 
     handler (FailureResponse _ Response{ responseStatusCode }) =
         return (Status.statusIsServerError responseStatusCode)


### PR DESCRIPTION
Prevent indefinite retries as reported here: https://github.com/Gabriella439/grace/issues/156#issuecomment-3418604951

I was still getting 500s from the create response endpoints when using `gpt-5-search-api`, even after creating new token.

Later I realized I created the tokens with permissions limited to "Model capabilities" endpoints (like /v1/chat/completions).
After I created a new token with unrestricted permissions, I stopped getting the 500s.

But I think it's sensible to avoid retrying indefinitely in any case.