### PR TITLE
Default `+` to `Natural` numbers

### DIFF
--- a/src/Grace/Infer.hs
+++ b/src/Grace/Infer.hs
@@ -2506,19 +2506,19 @@ infer e₀ = do
 
                     return (list, newOperator)
 
-            listArguments `Exception.catch` \(_ :: TypeInferenceError) -> do
+            naturalArguments `Exception.catch` \(_ :: TypeInferenceError) -> do
                 set context₁
 
-                textArguments `Exception.catch` \(_ :: TypeInferenceError) -> do
+                integerArguments `Exception.catch` \(_ :: TypeInferenceError) -> do
                     set context₁
 
-                    naturalArguments `Exception.catch` \(_ :: TypeInferenceError) -> do
+                    realArguments `Exception.catch` \(_ :: TypeInferenceError) -> do
                         set context₁
 
-                        integerArguments `Exception.catch` \(_ :: TypeInferenceError) -> do
+                        textArguments `Exception.catch` \(_ :: TypeInferenceError) -> do
                             set context₁
 
-                            realArguments `Exception.catch` \(_ :: TypeInferenceError) -> do
+                            listArguments `Exception.catch` \(_ :: TypeInferenceError) -> do
                                 Exception.throwIO (InvalidOperands "add" (Syntax.location left) (Syntax.location right))
 
         Syntax.Operator{ operator = Syntax.Minus, .. } -> do


### PR DESCRIPTION
Before this change if the argument type for `+` couldn't be inferred the type checker would assume `List` by default, but now it assumes `Natural` → `Integer` → `Real` by default.