### PR TITLE
Improve Grace REPL's support for assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Grace.
   The language provides a built-in `prompt` function for prompting a model:
 
   ```haskell
-  >>> :let key = ./openai.key : Key
+  >>> let key = ./openai.key : Key
 
   >>> prompt{ key, text: "Generate a list of names" }
   "
@@ -233,7 +233,7 @@ You can also use the `repl` subcommand for interactive usage:
 $ grace repl
 ```
 ```haskell
->>> :let key = ./openai-key.txt
+>>> let key = ./openai-key.txt
 >>> prompt{ key } : List { "First Name": Text, "Last Name": Text }
 [ { "First Name": "John", "Last Name": "Doe" }
 , { "First Name": "Jane", "Last Name": "Smith" }

--- a/src/Grace/Normalize.hs
+++ b/src/Grace/Normalize.hs
@@ -107,7 +107,7 @@ evaluate
 evaluate keyToMethods env₀ syntax₀ = do
     loop env₀ syntax₀
   where
-    generateContext location = do
+    generateContext env location = do
         let infer (name, assignment) = do
                 let expression :: Syntax Location Input
                     expression = first (\_ -> location) (fmap Void.absurd (quote assignment))
@@ -118,7 +118,7 @@ evaluate keyToMethods env₀ syntax₀ = do
 
                 return (name, type_, assignment)
 
-        traverse infer env₀
+        traverse infer env
 
     loop
         :: (MonadIO m, MonadState Status m, MonadCatch m)
@@ -400,7 +400,7 @@ evaluate keyToMethods env₀ syntax₀ = do
                     Left exception -> Exception.throwIO exception
                     Right prompt -> return prompt
 
-                Prompt.prompt (generateContext location) import_ location prompt schema
+                Prompt.prompt (generateContext env location) import_ location prompt schema
 
             Syntax.HTTP{ schema = Nothing } -> do
                 Exception.throwIO MissingSchema
@@ -415,7 +415,7 @@ evaluate keyToMethods env₀ syntax₀ = do
 
                 if import_
                     then do
-                        bindings <- liftIO (generateContext location)
+                        bindings <- liftIO (generateContext env location)
 
                         uri <- URI.mkURI (HTTP.url http)
 
@@ -452,7 +452,7 @@ evaluate keyToMethods env₀ syntax₀ = do
 
                 if import_
                     then do
-                        bindings <- generateContext location
+                        bindings <- generateContext env location
 
                         Status{ input = parent } <- State.get
 
@@ -506,7 +506,7 @@ evaluate keyToMethods env₀ syntax₀ = do
 
                 if import_
                     then do
-                        bindings <- generateContext location
+                        bindings <- generateContext env location
 
                         uri <- URI.mkURI url
 


### PR DESCRIPTION
Fixes https://github.com/Gabriella439/grace/issues/162

Now any assignment is a valid REPL expression, so you can do stuff like this:

```haskell
>>> let x = 1

>>> let y = x

>>> x + y
2

>>> let point = { x: 2, y: 3 }

>>> let { x, y, z = 4 } = point

>>> x
2

>>> y
3

>>> z
4
```