### PR TITLE
Fixes to monad elaboration

### DIFF
--- a/src/Grace/Parser.hs
+++ b/src/Grace/Parser.hs
@@ -1408,7 +1408,7 @@ grammar form = mdo
 
                 return \assignmentLocation -> Syntax.Bind
                     { assignmentLocation
-                    , monad = NoMonad
+                    , monad = Nothing
                     , binding
                     , assignment
                     }
@@ -1431,7 +1431,7 @@ grammar form = mdo
 
                 return Syntax.Bind
                     { assignmentLocation
-                    , monad = UnknownMonad
+                    , monad = Just UnknownMonad
                     , binding
                     , assignment
                     }

--- a/src/Grace/Syntax.hs
+++ b/src/Grace/Syntax.hs
@@ -1787,11 +1787,10 @@ instance Bifunctor Definition where
     second = fmap
 
 -- | The monad that a `Bind` takes place in
-data BindMonad = NoMonad | UnknownMonad | OptionalMonad | ListMonad
+data BindMonad = UnknownMonad | OptionalMonad | ListMonad
     deriving stock (Eq, Generic, Lift, Show)
 
 instance Pretty BindMonad where
-    pretty NoMonad       = "simple"
     pretty UnknownMonad  = "unknown"
     pretty OptionalMonad = Pretty.builtin "Optional"
     pretty ListMonad     = Pretty.builtin "List"
@@ -1812,7 +1811,7 @@ data Assignment s a
         }
     | Bind
         { assignmentLocation :: s
-        , monad :: BindMonad
+        , monad :: Maybe BindMonad
         , binding :: Binding s a
         , assignment :: Syntax s a
         }
@@ -1892,7 +1891,7 @@ instance Pretty a => Pretty (Assignment s a) where
             <>  punctuation "="
             <>  " "
             <>  pretty assignment
-    pretty Bind{ monad = NoMonad, binding, assignment } =
+    pretty Bind{ monad = Nothing, binding, assignment } =
         Pretty.group (Pretty.flatAlt long short)
       where
         long =  keyword "let"
@@ -1911,7 +1910,7 @@ instance Pretty a => Pretty (Assignment s a) where
             <>  punctuation "="
             <>  " "
             <>  pretty assignment
-    pretty Bind{ binding, assignment } =
+    pretty Bind{ monad = Just _, binding, assignment } =
         Pretty.group (Pretty.flatAlt long short)
       where
         long =  keyword "for"

--- a/tasty/data/error/type/for-mixed-stderr.txt
+++ b/tasty/data/error/type/for-mixed-stderr.txt
@@ -1,19 +1,17 @@
-Not a subtype
+Type constructor mismatch
 
-The following type:
+You cannot bind List expressions:
 
-  List Natural
-
-tasty/data/error/type/for-mixed-input.ffg:1:10: 
+tasty/data/error/type/for-mixed-input.ffg:1:1: 
   │
 1 │ for x of [ 1, 2, 3 ]
-  │          ↑
+  │ ↑
 
-… cannot be a subtype of:
-
-  Optional Natural
+ … and Optional expressions:
 
 tasty/data/error/type/for-mixed-input.ffg:3:1: 
   │
 3 │ for y of some 4
   │ ↑
+
+… within the same group of assignments.


### PR DESCRIPTION
Before this change an expression like:

```haskell
for x of xs

let y = z

…
```

… would get elaborated to:

```haskell
for x of xs

for y of z

…
```

… which would fail when `xs` was a `List` and `z` was not a `List`.

This change fixes the monad elaboration to leave `let` expressions undisturbed.