### PR TITLE
Document/fix `fold`s with missing fields

### DIFF
--- a/tasty/data/complex/fold-missing-field-input.ffg
+++ b/tasty/data/complex/fold-missing-field-input.ffg
@@ -1,0 +1,86 @@
+# This tests how `fold` behaves when missing various arguments, along with
+# commentary on why each case behaves the way it does:
+{ "Example 0":
+    # The inferred type will be:
+    #
+    #     Bool -> Optional Natural
+    #
+    # … because this will elaborate to:
+    #
+    #     fold{ false: some 0, true: null }
+    fold{ false: 0 }
+
+, "Example 1":
+    # This will also work because `fold`s for standard types (like `Bool`)
+    # tolerate extra fields.  Unfortunately this means that a typo (like `tru`
+    # instead of `true`) will be ignored and the intended field will default to
+    # `null`.  Fortunately, the type checker will catch that because a
+    # downstream step will fail if it does not expect an `Optional` value, such
+    # as:
+    #
+    #     fold{ false: 0, tru: 1 } + 2  # This will still fail to typecheck
+    fold{ false: 0, tru: 1 }
+
+, "Example 2":
+    # The inferred type will be:
+    #
+    #     forall (a : Type) . Natural -> Optional a`
+    #
+    # … because this will elaborate to:
+    #
+    #     fold{ succ x: x, zero: null }
+    #
+    # … and the inferred type correctly deduces that must always return `null`
+    # no matter what `Natural` number we provide.
+    fold{ succ x: x }
+
+, "Example 3":
+    # The inferred type will be:
+    #
+    #     < 'succ': Natural > -> Natural
+    #
+    # … because this cannot successfully type-check as a `fold` for `Natural`
+    # numbers.  This elaborates to:
+    #
+    #     fold{ succ x: x + 1, zero: null }
+    #
+    # … which doesn't work because if the accumulator is `Optional` then you
+    # can't add to it.  Since this doesn't work as a `Natural` number `fold` the
+    # type checker falls back to treating this as a union fold with `succ` as
+    # the alternative name.
+    fold{ succ x: x + 1 }
+
+, "Example 4":
+    # The inferred type will be:
+    #
+    #     forall (a : Type) . Optional (Optional a) -> Optional a
+    #
+    # … because this will elaborate to:
+    #
+    #     fold{ some x: x, null: null }
+    fold{ some x: x }
+
+, "Example 5":
+    # The inferred type will be:
+    #
+    #     Optional Natural -> Optional Natural
+    #
+    # … because this will elaborate to:
+    #
+    #     fold{ some x: some (x + 1), null: null }
+    #
+    # Note that (unlike the previous example) the typechecker has to insert a
+    # `some` around the `some` handler, which is why the inferred type has a
+    # different shape than the previous example.
+    fold{ some x: x + 1 }
+
+, "Example 6":
+    # The inferred type will be:
+    #
+    #     forall (a : Type) (b : Type) . List a -> Optional b
+    #
+    # … because this will elaborate to:
+    #
+    #     fold{ cons: \x y -> y, nil: null }
+    fold{ cons: \x y -> y }
+}

--- a/tasty/data/complex/fold-missing-field-output.ffg
+++ b/tasty/data/complex/fold-missing-field-output.ffg
@@ -1,0 +1,15 @@
+{ "Example 0":
+    fold { "false": 0, "true": null }
+, "Example 1":
+    fold { "false": 0, "true": null, "tru": 1 }
+, "Example 2":
+    fold { "succ": \x -> x, "zero": null }
+, "Example 3":
+    fold { "succ": \x -> x + 1 }
+, "Example 4":
+    fold { "some": \x -> x, "null": null }
+, "Example 5":
+    fold { "some": \x -> x + 1, "null": null }
+, "Example 6":
+    fold { "cons": \x y -> y, "nil": null }
+}

--- a/tasty/data/complex/fold-missing-field-type.ffg
+++ b/tasty/data/complex/fold-missing-field-type.ffg
@@ -1,0 +1,19 @@
+forall (a : Type) .
+forall (b : Type) .
+forall (c : Type) .
+forall (d : Type) .
+  { "Example 0":
+      Bool -> Optional Natural
+  , "Example 1":
+      Bool -> Optional Natural
+  , "Example 2":
+      Natural -> Optional a
+  , "Example 3":
+      < 'succ': Natural > -> Natural
+  , "Example 4":
+      Optional (Optional b) -> Optional b
+  , "Example 5":
+      Optional Natural -> Optional Natural
+  , "Example 6":
+      List c -> Optional d
+  }

--- a/tasty/data/error/type/fold-missing-field-input.ffg
+++ b/tasty/data/error/type/fold-missing-field-input.ffg
@@ -1,0 +1,24 @@
+# `fold`s can in some cases tolerate missing fields.  For example, this is a
+# valid `fold`:
+#
+#     fold{ succ x: x }
+#
+# … which elaborates to:
+#
+#     fold{ succ x: x, zero: null } : forall (a : Type) . Natural -> Optional a
+#
+# … but you cannot do it the other way around (keep `zero` and omit the `succ`),
+# because it is not a valid `fold` no matter how you interpret it.  If you
+# attempt to interpret it as a `fold` for `Natural` numbers the expression is
+# elaborated to:
+#
+#     fold{ succ: null, zero: 0 }
+#
+# … which doesn't work because the `succ` handler needs to be a function (and
+# `null` is not a function).  However, it also doesn't work if you fall back to
+# treating it as a fold for a union, because a fold for a union requires all
+# handlers to be functions (and `0` is not a function).
+#
+# The error message that you get if neither `fold` succeeds is the error message
+# for unions.
+fold{ zero: 0 }

--- a/tasty/data/error/type/fold-missing-field-stderr.txt
+++ b/tasty/data/error/type/fold-missing-field-stderr.txt
@@ -1,0 +1,19 @@
+Not a subtype
+
+The following type:
+
+  Natural
+
+tasty/data/error/type/fold-missing-field-input.ffg:24:13: 
+   │
+24 │ fold{ zero: 0 }
+   │             ↑
+
+… cannot be a subtype of:
+
+  d? -> c?
+
+tasty/data/error/type/fold-missing-field-input.ffg:24:1: 
+   │
+24 │ fold{ zero: 0 }
+   │ ↑


### PR DESCRIPTION
Fixes https://github.com/Gabriella439/grace/pull/180#discussion_r2476660043

Certain folds for built-in types (like `Natural` or `Optional`) can in certain circumstances work.  For example, this is a valid `fold`:

```haskell
fold{ false: 0 }
```

… because it elaborates to:

```haskell
fold{ false: some 0, true: null }
```

… so it has type `Bool -> Optional Natural` and evaluates accordingly:

```haskell
>>> fold{ false: 0 } false  # The `some` is stripped by the REPL
0
>>> fold{ false: 0 } true
null
```

However, this is not a valid `fold`:

```haskell
fold{ zero: 0 }
```

… because even if you elaborate it to:

```haskell
fold{ zero: 0, succ: null }
```

… that still doesn't type-check.  Nor does it type-check as a union `fold` either.

However, there is one case from before this change where the behavior was wrong.  This was not working before:

```haskell
fold{ false: 0, tru: 1 }  # Note the typo
```

… because the normalization logic for `Natural` numbers assumes that the set of fields is exactly `false` and `true` with no surplus fields. However, if you have a typo field like `tru` it still type-checks but then normalization fails because the set of fields doesn't exactly match.

However, it's fine if there are *fewer* fields because type inference will insert any missing fields as part of elaboration.

So the meat of this change is two main things:

- Fixing the normalization logic to handle extra fields

- Adding additional tests to document the expected behavior of `fold` in the presence of missing fields.