### PR TITLE
Importing plain `Text`/`Key` no longer requires annotation

### DIFF
--- a/prompts/inference.md
+++ b/prompts/inference.md
@@ -265,9 +265,9 @@ Of course, you *can* specify types if you want (and they're more lightweight tha
 
 ```bash
 $ grace repl
->>> prompt{ key: ./openai.key : Key, text: "Give me a first and last name" } : { first: Text, last: Text }
+>>> prompt{ key: ./openai.key, text: "Give me a first and last name" } : { first: Text, last: Text }
 { "first": "Emily", "last": "Johnson" }
->>> prompt{ key: ./openai.key : Key, text: "Give me a list of names" } : List Text
+>>> prompt{ key: ./openai.key, text: "Give me a list of names" } : List Text
 [ "Alice"
 , "Bob"
 , "Charlie"
@@ -384,7 +384,7 @@ What's particularly neat about this example is that the prompt is so incredibly 
 We can explore this idea of using the schema to drive the prompt instead of prose using an example like this:
 
 ```haskell
-prompt{ key: ./openai.key : Key, text: "Generate some characters for a story" }
+prompt{ key: ./openai.key, text: "Generate some characters for a story" }
   : List
     { "The character's name": Text
     , "The most memorable thing about the character": Text

--- a/src/Grace/Input.hs
+++ b/src/Grace/Input.hs
@@ -78,6 +78,11 @@ data Mode
     -- ^ Interpret the string as a Key
     deriving stock (Eq, Show)
 
+instance Semigroup Mode where
+    mode <> AsCode = mode
+
+    _ <> mode = mode
+
 instance Pretty Mode where
     pretty AsCode = mempty
     pretty AsText =

--- a/src/Grace/Interpret.hs
+++ b/src/Grace/Interpret.hs
@@ -16,7 +16,7 @@ import Data.Text (Text)
 import Grace.Decode (FromGrace(..))
 import Grace.HTTP (Methods)
 import Grace.Infer (Status(..))
-import Grace.Input (Input(..))
+import Grace.Input (Input(..), Mode(..))
 import Grace.Location (Location(..))
 import Grace.Type (Type)
 import Grace.Value (Value)
@@ -60,7 +60,7 @@ interpretWith
 interpretWith keyToMethods bindings maybeAnnotation = do
     Status{ input } <- State.get
 
-    expression <- liftIO (Import.resolve input)
+    expression <- liftIO (Import.resolve AsCode input)
 
     let annotatedExpression = case maybeAnnotation of
             Just annotation ->

--- a/tasty/data/unit/reveal-input.ffg
+++ b/tasty/data/unit/reveal-input.ffg
@@ -1,3 +1,3 @@
-let key = "abc" : Key
+let key = "abc"
 
 in  reveal key

--- a/try-grace/Main.hs
+++ b/try-grace/Main.hs
@@ -69,6 +69,7 @@ import qualified Grace.Decode as Decode
 import qualified Grace.HTTP as HTTP
 import qualified Grace.Import as Import
 import qualified Grace.Infer as Infer
+import qualified Grace.Input as Input
 import qualified Grace.Interpret as Interpret
 import qualified Grace.Monotype as Monotype
 import qualified Grace.Normalize as Normalize
@@ -1717,7 +1718,7 @@ main = do
                             }
 
                     let interpretOutput = do
-                            expression <- liftIO (Import.resolve input_)
+                            expression <- liftIO (Import.resolve Input.AsCode input_)
 
                             (inferred, elaboratedExpression) <- Infer.infer expression
 


### PR DESCRIPTION
Now if the import's type can be inferred to be `Text` or `Key` it will be imported as raw `Text` or a raw `Key`, which means that you can now do this:

```haskell
prompt{ key: ./openai.key, …}
```