### PR TITLE
Fix *another* parsing performance regression

### DIFF
--- a/src/Grace/Parser.hs
+++ b/src/Grace/Parser.hs
@@ -1259,12 +1259,6 @@ grammar form = mdo
 
                 return Syntax.Variable{ location, name }
 
-        <|> do  ~(location, name) <- locatedAlternative
-
-                argument <- primitiveExpression
-
-                return Syntax.Alternative{ location, name, argument }
-
         <|> do  location <- locatedToken Grace.Parser.OpenBracket
 
                 optional (parseToken Grace.Parser.Comma)


### PR DESCRIPTION
This is literally the exact same type of mistake as in #191, except for alternatives.  Alternatives could be parsed in two separate ways, so if you have N of them you get a 2^N blow up in the parser.