### PR TITLE
Factor out label-related logic into `Grace.Label` module

### DIFF
--- a/grace.cabal
+++ b/grace.cabal
@@ -53,10 +53,11 @@ library
                      , Grace.Existential
                      , Grace.GitHub
                      , Grace.HTTP
-                     , Grace.Input
                      , Grace.Import
-                     , Grace.Interpret
                      , Grace.Infer
+                     , Grace.Input
+                     , Grace.Interpret
+                     , Grace.Label
                      , Grace.Location
                      , Grace.Monotype
                      , Grace.Normalize

--- a/src/Grace/Label.hs
+++ b/src/Grace/Label.hs
@@ -1,0 +1,112 @@
+{-| This module provides label-related logic shared by the parser and
+    pretty-printer
+-}
+module Grace.Label
+    ( -- * Reserved tokens
+      reservedLabels
+    , reservedRecordLabels
+
+      -- * Character matching
+    , isLabel0
+    , isAlternativeLabel0
+    , isLabel
+
+      -- * Label quoting
+    , validLabel
+    , validRecordLabel
+    , validAlternativeLabel
+    ) where
+
+import Data.HashSet (HashSet)
+import Data.Text (Text)
+
+import qualified Data.Char as Char
+import qualified Data.HashSet as HashSet
+import qualified Data.Text as Text
+
+-- | Is this character valid as the first character in an unquoted label?
+isLabel0 :: Char -> Bool
+isLabel0 c = Char.isLower c || c == '_'
+
+-- | Is this character valid as the first character in an unquoted alternative
+-- label?
+isAlternativeLabel0 :: Char -> Bool
+isAlternativeLabel0 = Char.isUpper
+
+-- | Is this character valid as a follow-up character in an unquoted label?
+isLabel :: Char -> Bool
+isLabel c = Char.isAlphaNum c || c == '_' || c == '-' || c == '/'
+
+-- | Returns `True` if the given label is valid when unquoted
+validLabel :: Text -> Bool
+validLabel text_ =
+    case Text.uncons text_ of
+        Nothing ->
+            False
+        Just (h, t) ->
+                isLabel0 h
+            &&  Text.all isLabel t
+            &&  not (HashSet.member text_ reservedLabels)
+
+-- | Returns `True` if the given record label is valid when unquoted
+validRecordLabel :: Text -> Bool
+validRecordLabel text_ =
+    case Text.uncons text_ of
+        Nothing     -> False
+        Just (h, t) ->
+                isLabel0 h
+            &&  Text.all isLabel t
+            &&  not (HashSet.member text_ reservedRecordLabels)
+
+-- | Returns `True` if the given alternative label is valid when unquoted
+validAlternativeLabel :: Text -> Bool
+validAlternativeLabel text_ =
+    case Text.uncons text_ of
+        Nothing ->
+            False
+        Just (h, t) ->
+                isAlternativeLabel0 h
+            &&  Text.all isLabel t
+            &&  not (HashSet.member text_ reservedLabels)
+
+-- | Reserved tokens, which can't be used for labels unless they are quoted
+reservedLabels :: HashSet Text
+reservedLabels =
+    HashSet.union
+    (HashSet.fromList [ "some", "null", "true", "false" ])
+    reservedRecordLabels
+
+reservedRecordLabels :: HashSet Text
+reservedRecordLabels = HashSet.fromList
+    [ "Alternatives"
+    , "Bool"
+    , "Fields"
+    , "Integer"
+    , "List"
+    , "Natural"
+    , "Optional"
+    , "Real"
+    , "Text"
+    , "Type"
+    , "abs"
+    , "else"
+    , "fold"
+    , "for"
+    , "forall"
+    , "github"
+    , "http"
+    , "if"
+    , "import"
+    , "in"
+    , "indexed"
+    , "length"
+    , "let"
+    , "map"
+    , "of"
+    , "prompt"
+    , "read"
+    , "reveal"
+    , "show"
+    , "then"
+    , "yaml"
+    ]

--- a/src/Grace/Parser.hs
+++ b/src/Grace/Parser.hs
@@ -25,11 +25,6 @@ module Grace.Parser
     , REPLCommand(..)
       -- * Errors related to parsing
     , ParseError(..)
-      -- * Utilities
-    , reserved
-    , validLabel
-    , validRecordLabel
-    , validAlternativeLabel
     ) where
 
 import Control.Applicative (empty, many, optional, some, (<|>))
@@ -39,7 +34,6 @@ import Control.Exception.Safe (Exception(..))
 import Control.Monad.Combinators (manyTill)
 import Data.Functor (void)
 import Data.Foldable (toList)
-import Data.HashSet (HashSet)
 import Data.List.NonEmpty (NonEmpty(..), some1)
 import Data.Maybe (fromJust)
 import Data.Scientific (Scientific)
@@ -75,6 +69,7 @@ import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
 import qualified Data.Text.Read as Read
 import qualified Grace.Domain as Domain
+import qualified Grace.Label as Label
 import qualified Grace.Location as Location
 import qualified Grace.Monotype as Monotype
 import qualified Grace.Syntax as Syntax
@@ -189,7 +184,6 @@ lexToken =
 
         , lexText
         , lexAlternative
-        , lexQuotedAlternative
         ]
 
 lexLocatedToken :: Lexer LocatedToken
@@ -436,124 +430,43 @@ lexText = lexeme do
 
     return (TextLiteral dedented)
 
-isLabel0 :: Char -> Bool
-isLabel0 c = Char.isLower c || c == '_'
-
-isLabel :: Char -> Bool
-isLabel c = Char.isAlphaNum c || c == '_' || c == '-' || c == '/'
-
--- | Returns `True` if the given label is valid when unquoted
-validLabel :: Text -> Bool
-validLabel text_ =
-    case Text.uncons text_ of
-        Nothing ->
-            False
-        Just (h, t) ->
-                isLabel0 h
-            &&  Text.all isLabel t
-            &&  not (HashSet.member text_ reserved)
-
--- | Returns `True` if the given record label is valid when unquoted
-validRecordLabel :: Text -> Bool
-validRecordLabel text_ =
-    case Text.uncons text_ of
-        Nothing ->
-            False
-        Just (h, t) ->
-                (   isLabel0 h
-                &&  Text.all isLabel t
-                &&  not (HashSet.member text_ reserved)
-                )
-            ||  text_ == "null"
-            ||  text_ == "some"
-            ||  text_ == "true"
-            ||  text_ == "false"
-
--- | Returns `True` if the given alternative label is valid when unquoted
-validAlternativeLabel :: Text -> Bool
-validAlternativeLabel text_ =
-    case Text.uncons text_ of
-        Nothing ->
-            False
-        Just (h, t) ->
-                Char.isUpper h
-            &&  Text.all isLabel t
-            &&  not (HashSet.member text_ reserved)
-
--- | Reserved tokens, which can't be used for labels unless they are quoted
-reserved :: HashSet Text
-reserved =
-    HashSet.fromList
-        [ "Alternatives"
-        , "Bool"
-        , "Fields"
-        , "Integer"
-        , "List"
-        , "Natural"
-        , "Optional"
-        , "Real"
-        , "Text"
-        , "Type"
-        , "abs"
-        , "else"
-        , "false"
-        , "fold"
-        , "for"
-        , "forall"
-        , "github"
-        , "http"
-        , "if"
-        , "import"
-        , "in"
-        , "indexed"
-        , "length"
-        , "let"
-        , "map"
-        , "null"
-        , "of"
-        , "prompt"
-        , "read"
-        , "reveal"
-        , "show"
-        , "some"
-        , "then"
-        , "true"
-        , "yaml"
-        ]
-
 lexLabel :: Lexer Token
-lexLabel = lexeme (try lexUnquotedLabel <|> try lexQuotedLabel)
+lexLabel = lexUnquotedLabel <|> lexQuotedLabel
 
 lexUnquotedLabel :: Lexer Token
-lexUnquotedLabel = do
-    c0 <- Megaparsec.satisfy isLabel0 Megaparsec.<?> "label character"
+lexUnquotedLabel = (try . lexeme) do
+    c0 <- Megaparsec.satisfy Label.isLabel0 Megaparsec.<?> "label character"
 
-    cs <- Megaparsec.takeWhileP (Just "label character") isLabel
+    cs <- Megaparsec.takeWhileP (Just "label character") Label.isLabel
 
     let name = Text.cons c0 cs
 
-    Monad.guard (not (HashSet.member name reserved))
+    Monad.guard (not (HashSet.member name Label.reservedLabels))
 
     return (Label name)
 
 lexQuotedLabel :: Lexer Token
-lexQuotedLabel = do
+lexQuotedLabel = (try . lexeme) do
     "."
 
     name <- lexSingleQuoted
 
     return (Label name)
 
-lexAlternative :: Lexer Token
-lexAlternative = lexeme do
-    c0 <- Megaparsec.satisfy Char.isUpper Megaparsec.<?> "alternative character"
+lexUnquotedAlternative :: Lexer Token
+lexUnquotedAlternative = (try . lexeme) do
+    c0 <- Megaparsec.satisfy Label.isAlternativeLabel0 Megaparsec.<?> "alternative character"
 
-    cs <- Megaparsec.takeWhileP (Just "alternative character") isLabel
+    cs <- Megaparsec.takeWhileP (Just "alternative character") Label.isLabel
 
-    return (Grace.Parser.Alternative (Text.cons c0 cs))
+    let name = Text.cons c0 cs
+
+    Monad.guard (not (HashSet.member name Label.reservedLabels))
+
+    return (Grace.Parser.Alternative name)
 
 lexSingleQuoted :: Lexer Text
-lexSingleQuoted = lexeme do
+lexSingleQuoted = do
     "'"
 
     let isText c =
@@ -594,10 +507,13 @@ lexSingleQuoted = lexeme do
     return (Text.concat texts)
 
 lexQuotedAlternative :: Lexer Token
-lexQuotedAlternative = do
+lexQuotedAlternative = lexeme do
     name <- lexSingleQuoted
 
     return (Grace.Parser.Alternative name)
+
+lexAlternative :: Lexer Token
+lexAlternative = lexUnquotedAlternative <|> lexQuotedAlternative
 
 -- | Tokens produced by lexing
 data Token

--- a/src/Grace/Parser.hs-boot
+++ b/src/Grace/Parser.hs-boot
@@ -1,7 +1,0 @@
-module Grace.Parser where
-
-import Data.Text (Text)
-
-validLabel :: Text -> Bool
-validRecordLabel :: Text -> Bool
-validAlternativeLabel :: Text -> Bool

--- a/src/Grace/REPL.hs
+++ b/src/Grace/REPL.hs
@@ -18,7 +18,7 @@ import Grace.HTTP (Methods)
 import Grace.Infer (Status(..))
 import Grace.Interpret (Input(..))
 import Grace.Location (Location(..))
-import Grace.Parser (REPLCommand(..), reserved)
+import Grace.Parser (REPLCommand(..))
 import System.Console.Haskeline (Interrupt(..))
 import System.Console.Repline (CompleterStyle(..), MultiLine(..), ReplOpts(..))
 
@@ -32,6 +32,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text.IO
 import qualified Grace.Context as Context
 import qualified Grace.Infer as Infer
+import qualified Grace.Label as Label
 import qualified Grace.Normalize as Normalize
 import qualified Grace.Parser as Parser
 import qualified Grace.Pretty as Pretty
@@ -174,7 +175,7 @@ repl keyToMethods = do
                     ]
 
             completeReserved =
-                Repline.listCompleter (fmap Text.unpack (toList reserved))
+                Repline.listCompleter (fmap Text.unpack (toList Label.reservedLabels))
 
             completeIdentifiers args = do
                 assignments <- get

--- a/src/Grace/Type.hs
+++ b/src/Grace/Type.hs
@@ -54,10 +54,9 @@ import qualified Control.Lens as Lens
 import qualified Data.List as List
 import qualified Data.Text as Text
 import qualified Grace.Domain as Domain
+import qualified Grace.Label as Label
 import qualified Grace.Monotype as Monotype
 import qualified Prettyprinter as Pretty
-
-import {-# SOURCE #-} qualified Grace.Parser as Parser
 
 {- $setup
 
@@ -745,7 +744,7 @@ prettyRecordLabel
     -> Text
     -> Doc AnsiStyle
 prettyRecordLabel alwaysQuote field
-    | Parser.validRecordLabel field && not alwaysQuote =
+    | Label.validRecordLabel field && not alwaysQuote =
         label (pretty field)
     | otherwise =
         label (prettyTextLiteral field)
@@ -755,7 +754,7 @@ prettyAlternativeLabel
     :: Text
     -> Doc AnsiStyle
 prettyAlternativeLabel alternative
-    | Parser.validAlternativeLabel alternative =
+    | Label.validAlternativeLabel alternative =
         label (pretty alternative)
     | otherwise =
         label (prettyQuotedAlternative alternative)
@@ -765,7 +764,7 @@ prettyLabel
     :: Text
     -> Doc AnsiStyle
 prettyLabel name
-    | Parser.validLabel name =
+    | Label.validLabel name =
         label (pretty name)
     | otherwise =
         punctuation "." <> label (prettyQuotedAlternative name)


### PR DESCRIPTION
This also cleans up and consolidates some of the parsing logic along the way.