### PR TITLE
Fix `check` rule for `for` assignments

### DIFF
--- a/tasty/data/complex/for-lambda-input.ffg
+++ b/tasty/data/complex/for-lambda-input.ffg
@@ -1,0 +1,15 @@
+# This test verifies that the `check` rule for `for` assignments works
+# correctly when the type annotation is an unsolved variable,such as
+# when checking the body of a lambda without an annotation.
+\y ->
+
+{ "Example 0":
+    # This should get elaborated to `for x of some 1 in x` and have an
+    # inferred type of `Optional Natural` because if there is at least
+    # one `for` assignment then the type checker assumes that it must
+    # be *some* monad and the monad of last resort is always `Optional`
+    # (which will always succeed).
+    for x of 1 in x
+, "Example 1":
+    for x of [ 1 ] in x
+}

--- a/tasty/data/complex/for-lambda-output.ffg
+++ b/tasty/data/complex/for-lambda-output.ffg
@@ -1,0 +1,1 @@
+\y -> { "Example 0": for x of some 1 in x, "Example 1": for x of [ 1 ] in x }

--- a/tasty/data/complex/for-lambda-type.ffg
+++ b/tasty/data/complex/for-lambda-type.ffg
@@ -1,0 +1,2 @@
+forall (a : Type) .
+  a -> { "Example 0": Optional Natural, "Example 1": List Natural }

--- a/tasty/data/error/type/for-annotation-stderr.txt
+++ b/tasty/data/error/type/for-annotation-stderr.txt
@@ -13,7 +13,7 @@ tasty/data/error/type/for-annotation-input.ffg:1:21:
 
   Text
 
-tasty/data/error/type/for-annotation-input.ffg:1:31: 
+tasty/data/error/type/for-annotation-input.ffg:1:6: 
   │
 1 │ (for x of [] in x + 1) : List Text
-  │                               ↑
+  │      ↑


### PR DESCRIPTION
Long story short: the rule was not working correctly when a `for` assignment was checked against an unsolved type variable, which this fixes.

This was a bit tricky to properly fix because it requires checking the right-hand side into two steps:

- checking that the right-hand side is the right monad

  … which throws a `MonadMismatch` error that falls back to trying the next monad.

- checking that the right-hand side is the right element type

  … which throws a normal subtyping error which does not and should not fall back to trying the next monad.