### PR TITLE
Improve fold-related error messages

### DIFF
--- a/tasty/data/complex/abstract-fold-type.ffg
+++ b/tasty/data/complex/abstract-fold-type.ffg
@@ -1,1 +1,1 @@
-forall (a : Type) (b : Type) . { nil: a, cons: b -> a -> a } -> List b -> a
+forall (a : Type) . { } -> < > -> a

--- a/tasty/data/complex/fold-missing-field-input.ffg
+++ b/tasty/data/complex/fold-missing-field-input.ffg
@@ -11,17 +11,6 @@
     fold{ false: 0 }
 
 , "Example 1":
-    # This will also work because `fold`s for standard types (like `Bool`)
-    # tolerate extra fields.  Unfortunately this means that a typo (like `tru`
-    # instead of `true`) will be ignored and the intended field will default to
-    # `null`.  Fortunately, the type checker will catch that because a
-    # downstream step will fail if it does not expect an `Optional` value, such
-    # as:
-    #
-    #     fold{ false: 0, tru: 1 } + 2  # This will still fail to typecheck
-    fold{ false: 0, tru: 1 }
-
-, "Example 2":
     # The inferred type will be:
     #
     #     forall (a : Type) . Natural -> Optional a`
@@ -34,23 +23,7 @@
     # no matter what `Natural` number we provide.
     fold{ succ x: x }
 
-, "Example 3":
-    # The inferred type will be:
-    #
-    #     < 'succ': Natural > -> Natural
-    #
-    # … because this cannot successfully type-check as a `fold` for `Natural`
-    # numbers.  This elaborates to:
-    #
-    #     fold{ succ x: x + 1, zero: null }
-    #
-    # … which doesn't work because if the accumulator is `Optional` then you
-    # can't add to it.  Since this doesn't work as a `Natural` number `fold` the
-    # type checker falls back to treating this as a union fold with `succ` as
-    # the alternative name.
-    fold{ succ x: x + 1 }
-
-, "Example 4":
+, "Example 2":
     # The inferred type will be:
     #
     #     forall (a : Type) . Optional (Optional a) -> Optional a
@@ -60,7 +33,7 @@
     #     fold{ some x: x, null: null }
     fold{ some x: x }
 
-, "Example 5":
+, "Example 3":
     # The inferred type will be:
     #
     #     Optional Natural -> Optional Natural
@@ -74,7 +47,7 @@
     # different shape than the previous example.
     fold{ some x: x + 1 }
 
-, "Example 6":
+, "Example 4":
     # The inferred type will be:
     #
     #     forall (a : Type) (b : Type) . List a -> Optional b

--- a/tasty/data/complex/fold-missing-field-output.ffg
+++ b/tasty/data/complex/fold-missing-field-output.ffg
@@ -1,15 +1,11 @@
 { "Example 0":
     fold { "false": some 0, "true": null }
 , "Example 1":
-    fold { "false": some 0, "true": null, "tru": 1 }
-, "Example 2":
     fold { "succ": \x -> x, "zero": null }
-, "Example 3":
-    fold { "succ": \x -> x + 1 }
-, "Example 4":
+, "Example 2":
     fold { "some": \x -> x, "null": null }
-, "Example 5":
+, "Example 3":
     fold { "some": \x -> some (x + 1), "null": null }
-, "Example 6":
+, "Example 4":
     fold { "cons": \x y -> y, "nil": null }
 }

--- a/tasty/data/complex/fold-missing-field-type.ffg
+++ b/tasty/data/complex/fold-missing-field-type.ffg
@@ -5,15 +5,11 @@ forall (d : Type) .
   { "Example 0":
       Bool -> Optional Natural
   , "Example 1":
-      Bool -> Optional Natural
-  , "Example 2":
       Natural -> Optional d
-  , "Example 3":
-      < 'succ': Natural > -> Natural
-  , "Example 4":
+  , "Example 2":
       Optional (Optional c) -> Optional c
-  , "Example 5":
+  , "Example 3":
       Optional Natural -> Optional Natural
-  , "Example 6":
+  , "Example 4":
       List b -> Optional a
   }

--- a/tasty/data/error/type/fold-missing-field-input.ffg
+++ b/tasty/data/error/type/fold-missing-field-input.ffg
@@ -15,10 +15,5 @@
 #     fold{ succ: null, zero: 0 }
 #
 # … which doesn't work because the `succ` handler needs to be a function (and
-# `null` is not a function).  However, it also doesn't work if you fall back to
-# treating it as a fold for a union, because a fold for a union requires all
-# handlers to be functions (and `0` is not a function).
-#
-# The error message that you get if neither `fold` succeeds is the error message
-# for unions.
+# `null` is not a function).
 fold{ zero: 0 }

--- a/tasty/data/error/type/fold-missing-field-stderr.txt
+++ b/tasty/data/error/type/fold-missing-field-stderr.txt
@@ -1,19 +1,23 @@
-Not a subtype
+Record type mismatch
 
-The following type:
+The following record type:
 
-  Natural
+  { }
 
-tasty/data/error/type/fold-missing-field-input.ffg:24:13: 
+tasty/data/error/type/fold-missing-field-input.ffg:19:5: 
    │
-24 │ fold{ zero: 0 }
-   │             ↑
+19 │ fold{ zero: 0 }
+   │     ↑
 
-… cannot be a subtype of:
+… is not a subtype of the following record type:
 
-  e? -> d?
+  { succ: Natural -> Natural }
 
-tasty/data/error/type/fold-missing-field-input.ffg:24:1: 
+tasty/data/error/type/fold-missing-field-input.ffg:19:1: 
    │
-24 │ fold{ zero: 0 }
+19 │ fold{ zero: 0 }
    │ ↑
+
+The latter record has the following extra fields:
+
+• succ


### PR DESCRIPTION
The type-checker will no longer fall back to type checking a `fold` as a union if the provided fields are a non-empty subset of a standard fold type.  This should improve `fold`-related error messages, such as in the following case:

```haskell
fold { zero: 0 }
```

Before that would fall back to treating the `fold` as a union and now it recognizes that the user was attempting to `fold` a `Natural` number and it will report the `succ` field as missing.