### PR TITLE
Unify for comprehension checks

### DIFF
--- a/tasty/data/error/type/for-mixed-stderr.txt
+++ b/tasty/data/error/type/for-mixed-stderr.txt
@@ -2,18 +2,18 @@ Not a subtype
 
 The following type:
 
-  Optional Natural
+  List Natural
 
-tasty/data/error/type/for-mixed-input.ffg:3:10: 
+tasty/data/error/type/for-mixed-input.ffg:1:10: 
   │
-3 │ for y of some 4
+1 │ for x of [ 1, 2, 3 ]
   │          ↑
 
 … cannot be a subtype of:
 
-  List Natural
+  Optional Natural
 
-tasty/data/error/type/for-mixed-input.ffg:3:1: 
+tasty/data/error/type/for-mixed-input.ffg:1:1: 
   │
-3 │ for y of some 4
+1 │ for x of [ 1, 2, 3 ]
   │ ↑


### PR DESCRIPTION
This unifies the type inference logic for `for` comprehensions with the type checking logic for `for` comprehensions