### PR TITLE
trygrace.dev: Fix session storage for code inputs

### DIFF
--- a/try-grace/Main.hs
+++ b/try-grace/Main.hs
@@ -1421,7 +1421,7 @@ renderInputDefault path type_ = do
             Just t -> t
             Nothing -> ""
 
-    return $ (,) (Value.Scalar Null) do
+    return $ (,) (Value.Text text₀) do
         RenderInput{ keyToMethods, renderOutput, status, input } <- Reader.ask
 
         textarea <- createElement "textarea"


### PR DESCRIPTION
Before this change if you refreshed the page it would read `null` from a code input until the first time you changed it.  Now it correctly loads the old value on refresh.