### PR TITLE
trygrace.dev: Fix code inputs inside of a list

### DIFF
--- a/try-grace/Main.hs
+++ b/try-grace/Main.hs
@@ -1338,12 +1338,12 @@ renderInput path listType@Type.List{ type_ } = do
                 let index = Seq.length children₀
 
                 reader <-  case maybeReader of
-                        Just reader -> do
-                            return reader
-                        Nothing -> do
-                            (_, reader) <- process (fromIntegral index)
+                    Just reader -> do
+                        return reader
+                    Nothing -> do
+                        (_, reader) <- process (fromIntegral index)
 
-                            return reader
+                        return reader
 
                 IORef.atomicModifyIORef' childrenRef (\s -> (s |> _Child, ()))
 
@@ -1371,6 +1371,8 @@ renderInput path listType@Type.List{ type_ } = do
                 li <- createElement "li"
                 addClass li "grace-input-list-element"
 
+                before buttons li
+
                 case result of
                     Nothing -> do
                         return ()
@@ -1383,9 +1385,9 @@ renderInput path listType@Type.List{ type_ } = do
 
                         IORef.atomicModifyIORef' childrenRef (\m -> (adjust m, ()))
 
-                        nestedInvoke Change
+                        nestedRefresh
 
-                before buttons li
+                        nestedInvoke Change
 
         liftIO (traverse_ (insert . Just) readers)
 


### PR DESCRIPTION
Basically the problem this is solving is that you would get rendering issues if you tried to insert list elements for this program:

```haskell
\xs -> for x of xs in xs
```

The root of the problem is that CodeMirror elements need to be refreshed after they are displayed, which this change fixes.