### PR TITLE
trygrace.dev: fix invalid inputs

### DIFF
--- a/grace.cabal
+++ b/grace.cabal
@@ -165,6 +165,7 @@ executable try-grace
                      , grace
                      , insert-ordered-containers
                      , lens
+                     , mmorph
                      , mtl
                      , safe-exceptions
                      , scientific


### PR DESCRIPTION
This overhauls the logic to correctly handle invalid inputs like a code input that has invalid code or a JSON input that has invalid JSON.

The two main changes to the logic were:

- the starting value returned by `renderInput` is now a `Maybe`

  … in order to signal whether or not it is valid.  `Nothing` indicates that it's not a valid value.

- `renderOutput` now takes a `Maybe` input

  … so that it can hide the output if the input is invalid.