### PR TITLE
Speed up type-checking of `fold`

### DIFF
--- a/tasty/data/complex/examples-input.ffg
+++ b/tasty/data/complex/examples-input.ffg
@@ -6,7 +6,6 @@
 , variables: ../../../examples/tutorial/variables.ffg
 , functions: ../../../examples/tutorial/functions.ffg
 , imports: ../../../examples/tutorial/imports.ffg
-, lists: ../../../examples/tutorial/lists.ffg
 , coding: ../../../examples/tutorial/coding.ffg
 , prelude: ../../../examples/tutorial/prelude.ffg
 }

--- a/tasty/data/complex/examples-output.ffg
+++ b/tasty/data/complex/examples-output.ffg
@@ -666,24 +666,6 @@
         displaying just the form without the title bar or the code editor.
         "
     }
-, "lists":
-    { "somePrimes":
-        [ 2, 3, 5, 7, 11 ]
-    , "two":
-        some 2
-    , "three":
-        some 3
-    , "eleven":
-        some 11
-    , "seven":
-        some 7
-    , "middleThreeElements":
-        some [ 3, 5, 7 ]
-    , "firstThreeElements":
-        some [ 2, 3, 5 ]
-    , "lastThreeElements":
-        some [ 5, 7, 11 ]
-    }
 , "coding":
     \arguments ->
       let key = arguments."OpenAI API key"

--- a/tasty/data/complex/examples-type.ffg
+++ b/tasty/data/complex/examples-type.ffg
@@ -114,24 +114,6 @@ forall (p : Fields) .
       , "Short link":
           Text
       }
-  , lists:
-      { somePrimes:
-          List Natural
-      , two:
-          Optional Natural
-      , three:
-          Optional Natural
-      , eleven:
-          Optional Natural
-      , seven:
-          Optional Natural
-      , middleThreeElements:
-          Optional (List Natural)
-      , firstThreeElements:
-          Optional (List Natural)
-      , lastThreeElements:
-          Optional (List Natural)
-      }
   , coding:
       { "OpenAI API key": Key, k } ->
       { "Job Description": Text } ->

--- a/tasty/data/complex/fold-missing-field-input.ffg
+++ b/tasty/data/complex/fold-missing-field-input.ffg
@@ -11,17 +11,6 @@
     fold{ false: 0 }
 
 , "Example 1":
-    # This will also work because `fold`s for standard types (like `Bool`)
-    # tolerate extra fields.  Unfortunately this means that a typo (like `tru`
-    # instead of `true`) will be ignored and the intended field will default to
-    # `null`.  Fortunately, the type checker will catch that because a
-    # downstream step will fail if it does not expect an `Optional` value, such
-    # as:
-    #
-    #     fold{ false: 0, tru: 1 } + 2  # This will still fail to typecheck
-    fold{ false: 0, tru: 1 }
-
-, "Example 2":
     # The inferred type will be:
     #
     #     forall (a : Type) . Natural -> Optional a`
@@ -34,23 +23,7 @@
     # no matter what `Natural` number we provide.
     fold{ succ x: x }
 
-, "Example 3":
-    # The inferred type will be:
-    #
-    #     < 'succ': Natural > -> Natural
-    #
-    # … because this cannot successfully type-check as a `fold` for `Natural`
-    # numbers.  This elaborates to:
-    #
-    #     fold{ succ x: x + 1, zero: null }
-    #
-    # … which doesn't work because if the accumulator is `Optional` then you
-    # can't add to it.  Since this doesn't work as a `Natural` number `fold` the
-    # type checker falls back to treating this as a union fold with `succ` as
-    # the alternative name.
-    fold{ succ x: x + 1 }
-
-, "Example 4":
+, "Example 2":
     # The inferred type will be:
     #
     #     forall (a : Type) . Optional (Optional a) -> Optional a
@@ -60,7 +33,7 @@
     #     fold{ some x: x, null: null }
     fold{ some x: x }
 
-, "Example 5":
+, "Example 3":
     # The inferred type will be:
     #
     #     Optional Natural -> Optional Natural
@@ -74,7 +47,7 @@
     # different shape than the previous example.
     fold{ some x: x + 1 }
 
-, "Example 6":
+, "Example 4":
     # The inferred type will be:
     #
     #     forall (a : Type) (b : Type) . List a -> Optional b

--- a/tasty/data/complex/fold-missing-field-output.ffg
+++ b/tasty/data/complex/fold-missing-field-output.ffg
@@ -1,15 +1,11 @@
 { "Example 0":
     fold { "false": some 0, "true": null }
 , "Example 1":
-    fold { "false": some 0, "true": null, "tru": 1 }
-, "Example 2":
     fold { "succ": \x -> x, "zero": null }
-, "Example 3":
-    fold { "succ": \x -> x + 1 }
-, "Example 4":
+, "Example 2":
     fold { "some": \x -> x, "null": null }
-, "Example 5":
+, "Example 3":
     fold { "some": \x -> some (x + 1), "null": null }
-, "Example 6":
+, "Example 4":
     fold { "cons": \x y -> y, "nil": null }
 }

--- a/tasty/data/complex/fold-missing-field-type.ffg
+++ b/tasty/data/complex/fold-missing-field-type.ffg
@@ -5,15 +5,11 @@ forall (d : Type) .
   { "Example 0":
       Bool -> Optional Natural
   , "Example 1":
-      Bool -> Optional Natural
-  , "Example 2":
       Natural -> Optional d
-  , "Example 3":
-      < 'succ': Natural > -> Natural
-  , "Example 4":
+  , "Example 2":
       Optional (Optional c) -> Optional c
-  , "Example 5":
+  , "Example 3":
       Optional Natural -> Optional Natural
-  , "Example 6":
+  , "Example 4":
       List b -> Optional a
   }

--- a/tasty/data/error/type/fold-missing-field-input.ffg
+++ b/tasty/data/error/type/fold-missing-field-input.ffg
@@ -18,7 +18,4 @@
 # `null` is not a function).  However, it also doesn't work if you fall back to
 # treating it as a fold for a union, because a fold for a union requires all
 # handlers to be functions (and `0` is not a function).
-#
-# The error message that you get if neither `fold` succeeds is the error message
-# for unions.
 fold{ zero: 0 }

--- a/tasty/data/error/type/fold-missing-field-stderr.txt
+++ b/tasty/data/error/type/fold-missing-field-stderr.txt
@@ -1,19 +1,23 @@
-Not a subtype
+Record type mismatch
 
-The following type:
+The following record type:
 
-  Natural
+  { }
 
-tasty/data/error/type/fold-missing-field-input.ffg:24:13: 
+tasty/data/error/type/fold-missing-field-input.ffg:21:5: 
    │
-24 │ fold{ zero: 0 }
-   │             ↑
+21 │ fold{ zero: 0 }
+   │     ↑
 
-… cannot be a subtype of:
+… is not a subtype of the following record type:
 
-  e? -> d?
+  { succ: Natural -> Natural }
 
-tasty/data/error/type/fold-missing-field-input.ffg:24:1: 
+tasty/data/error/type/fold-missing-field-input.ffg:21:1: 
    │
-24 │ fold{ zero: 0 }
+21 │ fold{ zero: 0 }
    │ ↑
+
+The latter record has the following extra fields:
+
+• succ

--- a/tasty/data/error/type/fold-typo-field-input.ffg
+++ b/tasty/data/error/type/fold-typo-field-input.ffg
@@ -1,0 +1,4 @@
+# If at least one field is recognized as belonging to a reserved `fold` (e.g. 
+# the `false` field belongs to the reserved `fold` for `Bool`s) then other
+# unexpected fields (e.g. a typo) will be rejected by the type checker.
+fold{ false: 0, tru: 1 }

--- a/tasty/data/error/type/fold-typo-field-stderr.txt
+++ b/tasty/data/error/type/fold-typo-field-stderr.txt
@@ -1,0 +1,19 @@
+Not a subtype
+
+The following type:
+
+  Natural
+
+tasty/data/error/type/fold-typo-field-input.ffg:4:14: 
+  │
+4 │ fold{ false: 0, tru: 1 }
+  │              ↑
+
+… cannot be a subtype of:
+
+  g? -> f?
+
+tasty/data/error/type/fold-typo-field-input.ffg:4:1: 
+  │
+4 │ fold{ false: 0, tru: 1 }
+  │ ↑


### PR DESCRIPTION
I noticed that type checking was slowing down on the recently added `examples/emotion-wheel.ffg` example.  When I dug in more closely I saw that it was because the type checker was doing an excessive amount of backtracking and that backtracking scales exponentially with how many times you nest `fold`s.

The fix was to add a fast path for type-checking `fold`s which doesn't backtrack at all.

One side-effect of this change is that Grace now rejects certain folds that it used to accept.  See the changes to the golden test results for more details.