### PR TITLE
Improve error message for decoding

### DIFF
--- a/src/Grace.hs
+++ b/src/Grace.hs
@@ -187,7 +187,7 @@ main = Exception.handle handler do
 
             (inferred, value) <- Interpret.interpret input
 
-            let syntax = Normalize.strip (Normalize.quote value)
+            let syntax = Normalize.strip (Value.quote value)
 
             let annotatedExpression
                     | annotate = Annotation

--- a/src/Grace/Interpret.hs
+++ b/src/Grace/Interpret.hs
@@ -136,7 +136,7 @@ instance (ToGrace a, FromGrace b) => FromGrace (a -> IO b) where
 
             let initialStatus = Status{ count = 0, context = [] }
 
-            let code = Pretty.toText (Normalize.quote inputValue)
+            let code = Pretty.toText inputValue
 
             let input = Code "(decode)" code
 

--- a/src/Grace/REPL.hs
+++ b/src/Grace/REPL.hs
@@ -95,7 +95,7 @@ repl = do
                             let annotation = Context.complete context inferred
 
                             let annotated =
-                                    Normalize.quote (Value.complete context value)
+                                    Value.quote (Value.complete context value)
 
                             return (Right (annotation, annotated))
 

--- a/src/Grace/TH.hs
+++ b/src/Grace/TH.hs
@@ -27,7 +27,7 @@ import Prelude hiding (exp)
 
 import qualified Data.Text as Text
 import qualified Grace.Interpret as Interpret
-import qualified Grace.Normalize as Normalize
+import qualified Grace.Value as Value
 import qualified Language.Haskell.TH as TH
 import qualified Language.Haskell.TH.Syntax as TH
 
@@ -100,7 +100,7 @@ helperFunction f input = TH.Code do
 
     let type_ = void inferred
 
-    let syntax = Normalize.quote value
+    let syntax = Value.quote value
 
     exp <- TH.lift (f (type_, syntax))
 

--- a/tasty/Main.hs
+++ b/tasty/Main.hs
@@ -90,8 +90,7 @@ fileToTestTree prefix = do
         Right (inferred, value) -> do
             let generateTypeFile = return (pretty_ inferred)
 
-            let generateOutputFile =
-                    return (pretty_ (Normalize.quote value))
+            let generateOutputFile = return (pretty_ value)
 
             return
                 (Tasty.testGroup name

--- a/try-grace/Main.hs
+++ b/try-grace/Main.hs
@@ -422,7 +422,7 @@ typeToText :: Type s -> Text
 typeToText = Pretty.renderStrict False 80
 
 valueToText :: Value -> Text
-valueToText = Pretty.renderStrict False 80 . Normalize.quote
+valueToText = Pretty.renderStrict False 80
 
 hideElement :: MonadIO io => JSVal -> io ()
 hideElement element = do
@@ -791,7 +791,7 @@ fromStorage (Just text) = liftIO do
         return (Just a)
 
 toStorage :: ToGrace a => a -> Text
-toStorage a = Pretty.toText (Normalize.quote (encode a))
+toStorage a = Pretty.toText (encode a)
 
 renderInput
     :: [Text]


### PR DESCRIPTION
… this requires adding a `Pretty` instance for `Value` which in turn required some refactoring shenanigans to move the implementation of `quote` into the `Grace.Value` module, which kind of makes sense if you think about it.