### PR TITLE
Fix Grace support for `Optional` in JSON Schema

### DIFF
--- a/src/Grace/Prompt.hs
+++ b/src/Grace/Prompt.hs
@@ -148,8 +148,7 @@ toJSONSchema original = loop original
 
         return
             ( Aeson.object
-                [ ("type", "object")
-                , ("anyOf", Aeson.toJSON ([ present, absent ] :: [ Aeson.Value ]))
+                [ ("anyOf", Aeson.toJSON ([ present, absent ] :: [ Aeson.Value ]))
                 ]
             )
 
@@ -165,6 +164,8 @@ toJSONSchema original = loop original
 
         properties <- traverse toProperty fieldTypes
 
+        let required = fmap fst fieldTypes
+
         return
             ( Aeson.object
                 [ ("type", "object")
@@ -173,13 +174,6 @@ toJSONSchema original = loop original
                 , ("required", Aeson.toJSON required)
                 ]
             )
-      where
-        required = do
-            (field, type_) <- fieldTypes
-
-            case type_ of
-                Type.Optional{ } -> empty
-                _ -> return field
     loop Type.Union{ alternatives = Type.Alternatives alternativeTypes _ } = do
         let toAnyOf (alternative, type_) = do
                 contents <- loop type_


### PR DESCRIPTION
Before this change it was literally impossible for OpenAI to generate certain values with `Optional` in them because the schema was inconsistent.  For example, it would be impossible to generate `Optional Text` because the schema would insist that the schema was for an `object` when neither the present (`string`) nor absent (`null`) values were `object`s.

The fix was pretty simple: remove the `type: "object"`, which was not necessary and incorrect.

Also, this includes a fix so that all `Optional` fields are still `required` (although they can still be "present" and `null`), otherwise OpenAI will reject the schema.

Technically `Optional` support is not totally fixed.  It's still not possible (in the current generate JSON schema) to distinguish cases like `some null` or `null`.  I'll work on fixing that later when it becomes an issue.