### PR TITLE
trygrace.dev: Restore nested tabs

### DIFF
--- a/try-grace/Main.hs
+++ b/try-grace/Main.hs
@@ -628,15 +628,14 @@ renderValue parent outer (Value.Alternative location alternative value) = do
     renderValue parent recordType recordValue
 
 renderValue parent Type.Function{ location, input, output } function = do
-    r@Config{ status, input = input_ } <- Reader.ask
+    r@Config{ edit, status, input = input_ } <- Reader.ask
 
     outputVal <- createElement "div"
     addClass outputVal "grace-result"
 
     let hasEffects = Lens.has Value.effects function
 
-    -- TODO: Restore interior tabs with appropriate styling
-    let tabbed = False -- edit && hasEffects
+    let tabbed = edit && hasEffects
 
     (setBusy, setSuccess, setError) <- createForm tabbed outputVal
 

--- a/website/css/grace.css
+++ b/website/css/grace.css
@@ -196,7 +196,7 @@ li > span {
 }
 
 .grace-pane.grace-tabbed > * {
-  border-radius: 0 var(--s-2) var(--s-2) var(--s-2);
+  border-radius: var(--s-2);
 }
 
 .grace-form {
@@ -422,10 +422,11 @@ ul {
 
 .grace-tabs > * {
   flex: 0 0 auto;
+  margin-block-end: var(--s-3);
 }
 
 .grace-tabs > * + * {
-  margin-inline-start: var(--s-6);
+  margin-inline-start: var(--s-2);
 }
 
 .grace-tabs.overflowing {
@@ -438,17 +439,23 @@ ul {
 
 .grace-tab {
   border-radius: var(--s-2) var(--s-2) 0 0;
-  padding-inline: var(--s-1);
+  padding-inline: var(--s-2);
   padding-block: var(--s-2);
-  background-color: var(--crust);
+  background-color: transparent;
+  border-style: solid;
+  border-width: 0 0 var(--s-4) 0;
+  border-color: transparent;
 }
 
 .grace-tab:hover {
-  background-color: color-mix(in oklch, var(--overlay2) 30%, transparent);
+  color: var(--sky);
+  border-color: transparent transparent var(--sky) transparent;
+  background-color: transparent;
 }
 
 .grace-tab-selected {
-  background-color: var(--mantle);
+  color: var(--lavender);
+  border-color: transparent transparent var(--lavender) transparent;
 }
 
 .grace-spinner {


### PR DESCRIPTION
This fixes the TODO in `try-grace/Main,h.s` to show the "Form" / "Code" / "Type" tabs.  Fixing this required restyling the tabs so that they work against backgrounds of different colors.