### PR TITLE
Fix decoding unions into JSON for older `aeson` versions

### DIFF
--- a/src/Grace/Compat.hs
+++ b/src/Grace/Compat.hs
@@ -10,6 +10,8 @@ import Data.HashMap.Strict.InsOrd (InsOrdHashMap)
 import Data.Text (Text)
 
 import qualified Data.HashMap.Strict.InsOrd as HashMap
+import qualified Data.HashMap.Strict as HashMap.Strict
+import qualified Data.List as List
 
 #if MIN_VERSION_aeson(2, 0, 0)
 import Data.Aeson.KeyMap (KeyMap)
@@ -30,12 +32,18 @@ fromAesonMap = HashMap.fromHashMap . Aeson.toHashMapText
 
 toAesonMap :: InsOrdHashMap Text v -> KeyMap v
 toAesonMap = Aeson.fromHashMapText . HashMap.toHashMap
+
+sorted :: KeyMap value -> [(Text, value)]
+sorted = List.sortOn fst . HashMap.Strict.toList . Aeson.toHashMapText
 #else
 fromAesonMap :: HashMap Text v -> InsOrdHashMap Text v
 fromAesonMap = HashMap.fromHashMap
 
 toAesonMap :: InsOrdHashMap Text v -> HashMap Text v
 toAesonMap = HashMap.toHashMap
+
+sorted :: HashMap Text v -> [(Text, v)]
+sorted = List.sortOn fst . HashMap.Strict.toList
 #endif
 
 #if !MIN_VERSION_containers(0, 6, 6)

--- a/src/Grace/Infer.hs
+++ b/src/Grace/Infer.hs
@@ -4045,7 +4045,7 @@ solveSyntax _Γ = Lens.transform (Lens.over Syntax.types (Context.solveType _Γ)
 
 -- | Convert from JSON, inferring the value purely from the JSON data
 inferJSON :: Aeson.Value -> Value ()
-inferJSON (Aeson.Object [("contents", contents), ("tag", Aeson.String tag)]) =
+inferJSON (Aeson.Object (Compat.sorted -> [("contents", contents), ("tag", Aeson.String tag)])) =
     Value.Alternative () tag value
   where
     value = inferJSON contents
@@ -4077,7 +4077,7 @@ inferJSON Aeson.Null =
 checkJSON :: Type Location -> Aeson.Value -> Grace (Value ())
 checkJSON = loop []
   where
-    loop path Type.Union{ Type.alternatives = Type.Alternatives alternativeTypes _ } (Aeson.Object [("contents", contents), ("tag", Aeson.String tag)])
+    loop path Type.Union{ Type.alternatives = Type.Alternatives alternativeTypes _ } (Aeson.Object (Compat.sorted -> [("contents", contents), ("tag", Aeson.String tag)]))
         | Just alternativeType <- Prelude.lookup tag alternativeTypes = do
             value <- loop ("contents" : path) alternativeType contents
 

--- a/src/Grace/Normalize.hs
+++ b/src/Grace/Normalize.hs
@@ -46,7 +46,6 @@ import qualified Data.Aeson.Yaml as YAML
 import qualified Data.ByteString.Lazy as ByteString.Lazy
 import qualified Data.HashMap.Strict.InsOrd as HashMap
 import qualified Data.List as List
-import qualified Data.Ord as Ord
 import qualified Data.Scientific as Scientific
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
@@ -86,7 +85,7 @@ lookupVariable name environment = case Prelude.lookup name environment of
     Nothing    -> error "Grace.Normalize.lookupVariable: unbound variable"
 
 sorted :: Ord key => InsOrdHashMap key value -> [(key, value)]
-sorted = List.sortBy (Ord.comparing fst) . HashMap.toList
+sorted = List.sortOn fst . HashMap.toList
 
 {-| Evaluate an expression, leaving behind a `Value` free of reducible
     sub-expressions


### PR DESCRIPTION
This fixes the `inferJSON`/`checkJSON` to correctly decode unions into JSON.  This bug affected older versions of `aeson`, which includes the GHCJS support.