### PR TITLE
Improve type inference for function subtyping

### DIFF
--- a/src/Grace/Infer.hs
+++ b/src/Grace/Infer.hs
@@ -3203,82 +3203,31 @@ check Syntax.Lambda{ binding = Syntax.PlainBinding{ plain = Syntax.NameBinding{ 
 
         return Syntax.Lambda{ body = newBody, binding = newBinding, .. }
 
-check Syntax.Lambda{ binding = Syntax.PlainBinding{ plain = Syntax.NameBinding{ name, nameLocation, annotation = Just annotation, assignment = Nothing } }, .. } Type.Function{ location = _, ..} = do
-    subtype annotation input
-
+check annotated@Syntax.Lambda{ binding = Syntax.PlainBinding{ plain = Syntax.NameBinding{ name, nameLocation } } } Type.Function{ location = _, input, output } = do
     scoped (Context.Annotation name input) do
+        let body = Syntax.Application
+                { location = Syntax.location annotated
+                , function = annotated
+                , argument = Syntax.Variable
+                    { location = nameLocation
+                    , name
+                    }
+                }
+
         newBody <- check body output
 
-        context <- get
-
-        let newBinding = Syntax.PlainBinding
+        return Syntax.Lambda
+            { location = Syntax.location annotated
+            , binding = Syntax.PlainBinding
                 { plain = Syntax.NameBinding
-                    { nameLocation
-                    , name
-                    , annotation = Just (Context.solveType context annotation)
+                    { name
+                    , nameLocation
+                    , annotation = Just input
                     , assignment = Nothing
                     }
                 }
-
-        return Syntax.Lambda{ body = newBody, binding = newBinding, .. }
-
-check Syntax.Lambda{ binding = Syntax.PlainBinding{ plain = Syntax.NameBinding{ nameLocation, name, annotation = Nothing, assignment = Just assignment } }, .. } Type.Function{ location = _, input = input₀, output } = do
-    existential <- fresh
-
-    push (Context.UnsolvedType existential)
-
-    let input₁ = Type.UnsolvedType
-            { location = Syntax.location assignment
-            , existential
+            , body = newBody
             }
-
-    let optional = Type.Optional
-            { location = Syntax.location assignment
-            , type_ = input₁
-            }
-
-    subtype input₀ optional
-
-    newAssignment <- check assignment input₁
-
-    scoped (Context.Annotation name input₁) do
-        newBody <- check body output
-
-        let newBinding = Syntax.PlainBinding
-                { plain = Syntax.NameBinding
-                    { nameLocation
-                    , name
-                    , annotation = Nothing
-                    , assignment = Just newAssignment
-                    }
-                }
-
-        return Syntax.Lambda{ body = newBody, binding = newBinding, .. }
-
-check Syntax.Lambda{ binding = Syntax.PlainBinding{ plain = Syntax.NameBinding{ name, nameLocation, annotation = Just annotation, assignment = Just assignment } }, .. } Type.Function{ location = _, ..} = do
-    newAssignment <- check assignment annotation
-
-    context₀ <- get
-
-    subtype (Context.solveType context₀ annotation) (Context.solveType context₀ input)
-
-    scoped (Context.Annotation name input) do
-        context₁ <- get
-
-        newBody <- check body (Context.solveType context₁ output)
-
-        context₂ <- get
-
-        let newBinding = Syntax.PlainBinding
-                { plain = Syntax.NameBinding
-                    { nameLocation
-                    , name
-                    , annotation = Just (Context.solveType context₂ annotation)
-                    , assignment = Just newAssignment
-                    }
-                }
-
-        return Syntax.Lambda{ body = newBody, binding = newBinding, .. }
 
 check e Type.Forall{..} = do
     scoped (Context.Variable domain name) do

--- a/tasty/data/complex/subtype-function-input.ffg
+++ b/tasty/data/complex/subtype-function-input.ffg
@@ -1,0 +1,1 @@
+(\(x : Integer) -> x) : Natural -> Integer

--- a/tasty/data/complex/subtype-function-output.ffg
+++ b/tasty/data/complex/subtype-function-output.ffg
@@ -1,0 +1,1 @@
+\x -> (\(x : Integer) -> x) (x : Integer)

--- a/tasty/data/complex/subtype-function-type.ffg
+++ b/tasty/data/complex/subtype-function-type.ffg
@@ -1,0 +1,1 @@
+Natural -> Integer

--- a/tasty/data/error/type/subtype-function-input.ffg
+++ b/tasty/data/error/type/subtype-function-input.ffg
@@ -1,0 +1,1 @@
+(\(x : Natural) -> x) : Integer -> Natural

--- a/tasty/data/error/type/subtype-function-stderr.txt
+++ b/tasty/data/error/type/subtype-function-stderr.txt
@@ -1,0 +1,19 @@
+Not a subtype
+
+The following type:
+
+  Integer
+
+tasty/data/error/type/subtype-function-input.ffg:1:25: 
+  │
+1 │ (\(x : Natural) -> x) : Integer -> Natural
+  │                         ↑
+
+… cannot be a subtype of:
+
+  Natural
+
+tasty/data/error/type/subtype-function-input.ffg:1:8: 
+  │
+1 │ (\(x : Natural) -> x) : Integer -> Natural
+  │        ↑


### PR DESCRIPTION
Before this change something like this would not type-check:

```haskell
(\(x : Integer) -> x) : Natural -> Integer
```

… because it relied on a `subtype` judgment to unify the two input types, which prevented the interpreter from inserting an explicit coercion between `Natural` and `Integer`.

After this change (which no longer makes use of the `subtype` judgement), the code now type-checks.