### PR TITLE
Fix supertype computation

### DIFF
--- a/src/Grace/Infer.hs
+++ b/src/Grace/Infer.hs
@@ -270,10 +270,11 @@ supertypeOf a b = do
     context₀ <- get
 
     case (a, b) of
-        (UnsolvedType{ location, existential = existential₀ }, UnsolvedType { existential = existential₁ }) -> do
-            equateTypes existential₀ existential₁
+        (type₀@UnsolvedType{ existential = existential₀ }, UnsolvedType { existential = existential₁ }) -> do
+            Monad.unless (existential₀ == existential₁) do
+                equateTypes existential₀ existential₁
 
-            return UnsolvedType{ location, existential = existential₀ }
+            return type₀
 
         (UnsolvedType{ existential }, type_)
             | not (existential `Type.typeFreeIn` type_)
@@ -331,10 +332,17 @@ supertypeOf a b = do
 
             both <- sequence (Map.intersectionWith combine map₀ map₁)
 
-            let optional location type_ = Optional{ location, type_ }
+            let optional location type_ = do
+                    context <- get
 
-            let extra₀ = fmap (optional location₀) (Map.difference map₀ map₁)
-            let extra₁ = fmap (optional location₁) (Map.difference map₁ map₀)
+                    required <- isFieldRequired (Context.solveType context type_)
+
+                    if required
+                        then return Optional{ location, type_ }
+                        else return type_
+
+            extra₀ <- traverse (optional location₀) (Map.difference map₀ map₁)
+            extra₁ <- traverse (optional location₁) (Map.difference map₁ map₀)
 
             let fieldTypes = Map.toList (both <> extra₀ <> extra₁)
 
@@ -483,10 +491,11 @@ subtypeOf a b = do
     context₀ <- get
 
     case (a, b) of
-        (UnsolvedType{ location, existential = existential₀ }, UnsolvedType { existential = existential₁ }) -> do
-            equateTypes existential₀ existential₁
+        (type₀@UnsolvedType{ existential = existential₀ }, UnsolvedType { existential = existential₁ }) -> do
+            Monad.unless (existential₀ == existential₁) do
+                equateTypes existential₀ existential₁
 
-            return UnsolvedType{ location, existential = existential₀ }
+            return type₀
 
         (UnsolvedType{ existential }, type_)
             | not (existential `Type.typeFreeIn` type_)
@@ -4786,7 +4795,7 @@ instance Exception TypeInferenceError where
     displayException (MissingOneOfTypes locations existential₀ existential₁ _Γ) =
         "Internal error: Invalid context\n\
         \\n\
-        \One of the following fields variables:\\n\
+        \One of the following type variables:\n\
         \\n\
         \" <> listToText [Context.UnsolvedType existential₀, Context.UnsolvedType existential₁ ] <> "\n\
         \\n\

--- a/tasty/data/complex/triple-supertype-input.ffg
+++ b/tasty/data/complex/triple-supertype-input.ffg
@@ -1,0 +1,16 @@
+# This test ensures that a supertype of 3 or more values doesn't wrap optional
+# fields in more than one layer of `Optional`.  The expected type should be
+#
+#     List { x: Optional Natural, y: Optional Natural, z: Optional Natural }
+#
+# … and not something like:
+#
+#     List
+#         { x: Optional (Optional Natural)
+#         , y: Optional (Optional Natural)
+#         , z: Optional Natural
+#         }
+#
+# More generally, getting this correct ensures that the most-specific supertype
+# operation is associative and commutative.
+[ { x: 1 }, { y: 1 }, { z: 1 } ]

--- a/tasty/data/complex/triple-supertype-output.ffg
+++ b/tasty/data/complex/triple-supertype-output.ffg
@@ -1,0 +1,4 @@
+[ { "x": some 1, "y": null, "z": null }
+, { "y": some 1, "x": null, "z": null }
+, { "z": some 1, "x": null, "y": null }
+]

--- a/tasty/data/complex/triple-supertype-type.ffg
+++ b/tasty/data/complex/triple-supertype-type.ffg
@@ -1,0 +1,1 @@
+List { x: Optional Natural, y: Optional Natural, z: Optional Natural }

--- a/tasty/data/error/type/unify-unsolved-output.ffg
+++ b/tasty/data/error/type/unify-unsolved-output.ffg
@@ -1,0 +1,22 @@
+\r ->
+\s ->
+\x ->
+  let a = r.x
+
+  let b = s.y
+
+  let c = L 1
+
+  let d = R true
+
+  in  { "example0":
+          [ r, s ]
+      , "example1":
+          [ r, r ]
+      , "example2":
+          [ c, d ]
+      , "example3":
+          [ c, c ]
+      , "example4":
+          [ x, x ]
+      }

--- a/tasty/data/error/type/unify-unsolved-type.ffg
+++ b/tasty/data/error/type/unify-unsolved-type.ffg
@@ -1,0 +1,19 @@
+forall (a : Type) .
+forall (b : Alternatives) .
+forall (c : Type) .
+forall (d : Fields) .
+forall (e : Type) .
+  { x: Optional c, d } ->
+  { y: Optional e, d } ->
+  a ->
+    { example0:
+        List { x: Optional c, y: Optional e, d }
+    , example1:
+        List { x: Optional c, d }
+    , example2:
+        List < L: Natural | R: Bool | b >
+    , example3:
+        List < L: Natural | b >
+    , example4:
+        List a
+    }


### PR DESCRIPTION
Without this fix the `supertype` operation is not associative or commutative because it will adding multiple `Optional` layers depending on the order in which the `supertype` operations are nested.

The fix is to change the `optional` function to only make a field `Optional` if it wasn't already `Optional`.