### PR TITLE
Improve `check` case for `Optional`

### DIFF
--- a/src/Grace/Infer.hs
+++ b/src/Grace/Infer.hs
@@ -54,7 +54,13 @@ import Grace.Type (Type(..))
 import Grace.Value (Value)
 
 import Grace.Syntax
-    (Binding, BindMonad(..), Definition(..), NameBinding, Syntax)
+    ( Assignment(..)
+    , Binding(..)
+    , BindMonad(..)
+    , Definition(..)
+    , NameBinding(NameBinding)
+    , Syntax
+    )
 
 import qualified Control.Exception.Safe as Exception
 import qualified Control.Lens as Lens
@@ -4256,30 +4262,83 @@ check Syntax.Project{ location, larger, smaller = smaller@Syntax.Index{ } } Type
 
     return Syntax.Project{ location, larger = newLarger, smaller }
 
-check Syntax.Scalar{ scalar = Syntax.Null, .. } Type.Optional{ } = do
-    return Syntax.Scalar{ scalar = Syntax.Null, .. }
+check Syntax.Scalar{ location, scalar = Syntax.Null } Type.Optional{ } = do
+    return Syntax.Scalar{ location, scalar = Syntax.Null }
 
-check Syntax.Application{ location = location₀, function = Syntax.Builtin{ location = location₁, builtin = Syntax.Some }, argument = e } Type.Optional{ type_ } = do
-    newE <- check e type_
-    return Syntax.Application{ location = location₀, function = Syntax.Builtin{ location = location₁, builtin = Syntax.Some }, argument = newE }
+check Syntax.Application{ location = location₀, function = Syntax.Builtin{ location = location₁, builtin = Syntax.Some }, argument } Type.Optional{ type_ } = do
+    newArgument <- check argument type_
 
-check e _B@Type.Optional{ type_ } = do
-    let normal = do
-            (_A₀, newE) <- infer e
+    return Syntax.Application
+        { location = location₀
+        , function = Syntax.Builtin
+            { location = location₁
+            , builtin = Syntax.Some
+            }
+        , argument = newArgument
+        }
 
-            _Θ <- get
+check annotated annotation@Type.Optional{ location, type_ = type₀ } = do
+    let name = "x"
 
-            subtype (Context.solveType _Θ _A₀) (Context.solveType _Θ _B)
+    (type₁, newAnnotated₀) <- infer annotated
 
-            return newE
+    context₀ <- get
 
-    normal `Exception.catch` \(typeInferenceError :: TypeInferenceError) -> do
-        newE <- check e type_ `Exception.catch` \(_ :: TypeInferenceError) -> do
-            Exception.throwIO typeInferenceError
+    case Context.solveType context₀ type₁ of
+        Type.Optional{ type_ = type₂ } -> do
+            scoped (Context.Annotation name type₂) do
+                let nameLocation = Type.location type₀
 
-        let location = Syntax.location e
+                let variable = Syntax.Variable{ location = nameLocation, name }
 
-        return Syntax.Application{ function = Syntax.Builtin{ builtin = Syntax.Some, .. }, argument = newE, .. }
+                context₁ <- get
+
+                elaborated <- check variable (Context.solveType context₁ type₀)
+
+                if elaborated == variable
+                    then do
+                        return newAnnotated₀
+                    else do
+                        return Syntax.Let
+                            { location
+                            , assignments =
+                                [ Bind
+                                    { assignmentLocation = location
+                                    , monad = OptionalMonad
+                                    , binding = PlainBinding
+                                        { plain = NameBinding
+                                            { nameLocation
+                                            , name
+                                            , annotation = Just type₂
+                                            , assignment = Nothing
+                                            }
+                                        }
+                                    , assignment = newAnnotated₀
+                                    }
+                                ]
+                            , body = elaborated
+                            }
+
+        Type.UnsolvedType{ existential } -> do
+            instantiateTypeL existential (Context.solveType context₀ annotation)
+
+            context₁ <- get
+
+            return (solveSyntax context₁ newAnnotated₀)
+
+        _ -> do
+            newAnnotated₁ <- check annotated (Context.solveType context₀ type₀)
+
+            context₁ <- get
+
+            return Syntax.Application
+                { location
+                , function = Syntax.Builtin
+                    { location
+                    , builtin = Syntax.Some
+                    }
+                , argument = solveSyntax context₁ newAnnotated₁
+                }
 
 check Syntax.Operator{ location, left, operatorLocation, operator = Syntax.Times, right } annotation@Type.Scalar{ scalar }
     | scalar `elem` ([ Monotype.Natural, Monotype.Integer, Monotype.Real ] :: [Monotype.Scalar]) = do

--- a/tasty/data/complex/elaborate-inside-optional-input.ffg
+++ b/tasty/data/complex/elaborate-inside-optional-input.ffg
@@ -1,0 +1,1 @@
+\(x : Optional Natural) -> x : Optional (Optional Natural)

--- a/tasty/data/complex/elaborate-inside-optional-output.ffg
+++ b/tasty/data/complex/elaborate-inside-optional-output.ffg
@@ -1,0 +1,1 @@
+\x -> (if let (x : Natural) of x in some x) : Optional (Optional Natural)

--- a/tasty/data/complex/elaborate-inside-optional-type.ffg
+++ b/tasty/data/complex/elaborate-inside-optional-type.ffg
@@ -1,0 +1,1 @@
+Optional Natural -> Optional (Optional Natural)


### PR DESCRIPTION
This change is part of my epic journey to remove the `subtype` judgment from the internals.  The rationale behind doing this is to ensure that every mismatch between a subtype and a supertype is fixed with an explicit conversion in the internal language and the `subtype` judgment is problematic because it performs no elaboration.

This fixes the `check` case for `Optional` to respect this rule: now the fallback case no longer uses the `subtype` judgment.  Instead, we lift elaboration over the element type.

The only code this changes is code that was broken before (missing an elaboration).  Code that was properly elaborated before this change produces the exact same result and inferred type as before.  In fact, this change did not have any affect on the current golden tests, although I have hit this issue in the wild even if it wasn't covered by the existing test suite.

The easiest way to motivate this fix is the test that I just added:

```haskell
\(x : Optional Natural) -> x : Optional (Optional Natural)
```

Before this fix that would have been elaborated to the exact same expression as before, which is incorrect (no `some` is inserted anywhere in the expression, which means that this code will break in subtle ways when evaluated).

After this fix it now elaborates to:

```haskell
+\x -> (if let (x : Natural) of x in some x) : Optional (Optional Natural)
```

… in other words, it maps `some` over the outer `Optional` to fix the element type (`Natural`) to match the expected element type (`Optional Natural`).