### PR TITLE
Add `check` case for functions

### DIFF
--- a/src/Grace/Infer.hs
+++ b/src/Grace/Infer.hs
@@ -3973,10 +3973,8 @@ check :: Syntax Location Input -> Type Location -> Grace (Syntax Location Void)
 -- type annotations to fix any type errors that they might encounter, which is
 -- a desirable property!
 
-check Syntax.Lambda{ binding = Syntax.PlainBinding{ plain = Syntax.NameBinding{ name, nameLocation, annotation = Nothing, assignment = Nothing } }, ..} Type.Function{ location = _, .. } = do
+check Syntax.Lambda{ location, binding = Syntax.PlainBinding{ plain = Syntax.NameBinding{ name, nameLocation, annotation = Nothing, assignment = Nothing } }, body } Type.Function{ input, output } = do
     scoped (Context.Annotation name input) do
-        newBody <- check body output
-
         let newBinding = Syntax.PlainBinding
                 { plain = Syntax.NameBinding
                     { nameLocation
@@ -3986,33 +3984,61 @@ check Syntax.Lambda{ binding = Syntax.PlainBinding{ plain = Syntax.NameBinding{ 
                     }
                 }
 
-        return Syntax.Lambda{ body = newBody, binding = newBinding, .. }
+        newBody <- check body output
 
-check annotated@Syntax.Lambda{ binding = Syntax.PlainBinding{ plain = Syntax.NameBinding{ name, nameLocation } } } Type.Function{ location = _, input, output } = do
+        return Syntax.Lambda{ location, binding = newBinding, body = newBody }
+
+check annotated Type.Function{ input, output } = do
+    let candidates₀ = Set.fromList (map Text.singleton [ 'a' .. 'z' ])
+
+    let free = Syntax.freeVariables annotated
+
+    let name = case Set.toList (Set.difference candidates₀ free) of
+            n : _ -> n
+            _ ->
+                let as = Set.filter (Text.isPrefixOf "a") free
+
+                in  head do
+                        suffix <- [ (0 :: Int) .. ]
+
+                        let candidate = Text.pack ("a" <> show suffix)
+
+                        Monad.guard (not (Set.member candidate as))
+
+                        return candidate
+
+    let nameLocation = Type.location input
+
     scoped (Context.Annotation name input) do
+        let argument = Syntax.Variable{ location = nameLocation, name }
+
         let body = Syntax.Application
                 { location = Syntax.location annotated
                 , function = annotated
-                , argument = Syntax.Variable
-                    { location = nameLocation
-                    , name
-                    }
+                , argument
                 }
 
-        newBody <- check body output
+        context <- get
 
-        return Syntax.Lambda
-            { location = Syntax.location annotated
-            , binding = Syntax.PlainBinding
-                { plain = Syntax.NameBinding
-                    { name
-                    , nameLocation
-                    , annotation = Just input
-                    , assignment = Nothing
-                    }
-                }
-            , body = newBody
-            }
+        newBody <- check body (Context.solveType context output)
+
+        case newBody of
+            Syntax.Application{ function = newAnnotated, argument = Syntax.Variable{ name = newName } }
+                | name == newName && not (Syntax.usedIn name newAnnotated) ->
+                    return newAnnotated
+            _ -> do
+                    return Syntax.Lambda
+                        { location = Syntax.location annotated
+                        , binding = Syntax.PlainBinding
+                            { plain = Syntax.NameBinding
+                                { name
+                                , nameLocation
+                                , annotation = Nothing
+                                , assignment = Nothing
+                                }
+                            }
+                        , body = newBody
+                        }
 
 check e Type.Forall{..} = do
     scoped (Context.Variable domain name) do

--- a/src/Grace/Syntax.hs
+++ b/src/Grace/Syntax.hs
@@ -9,6 +9,7 @@ module Grace.Syntax
     ( -- * Syntax
       Syntax(..)
     , usedIn
+    , freeVariables
     , effects
     , types
     , complete
@@ -33,6 +34,7 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.Monoid (Any)
 import Data.Scientific (Scientific)
 import Data.Sequence (Seq((:<|)))
+import Data.Set (Set)
 import Data.String (IsString(..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -62,6 +64,7 @@ import Prettyprinter.Internal
 import qualified Control.Lens as Lens
 import qualified Control.Monad as Monad
 import qualified Data.Aeson as Aeson
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Grace.Context as Context
 import qualified Grace.Pretty as Pretty
@@ -734,7 +737,7 @@ usedIn name₀ List{ elements } =
 usedIn name₀ Record{ fieldValues } = any onDefinition fieldValues
   where
     onDefinition Definition{ bindings, assignment } =
-        name₀ `notElem` concatMap toNames bindings || usedIn name₀ assignment
+        name₀ `notElem` concatMap toNames bindings && usedIn name₀ assignment
 
     toName NameBinding{ name = name₁ } = name₁
 
@@ -747,7 +750,7 @@ usedIn name₀ Alternative{ argument } =
 usedIn name₀ Fold{ handlers } =
     usedIn name₀ handlers
 usedIn name₀ If{ predicate, ifTrue, ifFalse } =
-    usedIn name₀ predicate && usedIn name₀ ifTrue && usedIn name₀ ifFalse
+    usedIn name₀ predicate || usedIn name₀ ifTrue || usedIn name₀ ifFalse
 usedIn name₀ Text{ chunks = Chunks _ pairs } =
     any (usedIn name₀ . fst) pairs
 usedIn _ Scalar{ } =
@@ -763,11 +766,85 @@ usedIn name₀ GitHub{ arguments } =
 usedIn name₀ Show{ arguments } =
     usedIn name₀ arguments
 usedIn name₀ Operator{ left, right } =
-    usedIn name₀ left && usedIn name₀ right
+    usedIn name₀ left || usedIn name₀ right
 usedIn _ Builtin{ } =
     False
 usedIn _ Embed{ } =
     False
+
+-- | Returns all free variables within an expression
+freeVariables :: Syntax s a -> Set Text
+freeVariables Variable{ name } = Set.singleton name
+freeVariables Lambda{ binding = PlainBinding{ plain = NameBinding{ name } }, body } =
+    Set.delete name (freeVariables body)
+freeVariables Lambda{ binding = RecordBinding{ fieldNames }, body } =
+    Set.difference (freeVariables body) (Set.fromList (map toName fieldNames))
+  where
+    toName NameBinding{ name = name₁ } = name₁
+freeVariables Application{ function, argument } =
+    Set.union (freeVariables function) (freeVariables argument)
+freeVariables Annotation{ annotated } =
+    freeVariables annotated
+freeVariables Let{ assignments = Define{ definition = Definition{ name, assignment } } :| [], body } =
+    Set.union (freeVariables assignment) (Set.delete name (freeVariables body))
+freeVariables Let{ assignments = Bind{ binding, assignment } :| [], body } =
+    Set.union (freeVariables assignment) (Set.difference (freeVariables body) (Set.fromList (toNames binding)))
+  where
+    toName NameBinding{ name = name₁ } = name₁
+
+    toNames PlainBinding{ plain } = [ toName plain ]
+    toNames RecordBinding{ fieldNames } = map toName fieldNames
+freeVariables Let{ location, assignments = Define{ definition = Definition{ name, assignment } } :| (a : as), body } =
+    Set.union (freeVariables assignment) (Set.delete name (freeVariables Let{ location, assignments = a :| as, body }))
+freeVariables Let{ location, assignments = Bind{ binding, assignment } :| (a : as), body } =
+    Set.union (freeVariables assignment) (Set.difference (freeVariables Let{ location, assignments = a :| as, body }) (Set.fromList (toNames binding)))
+  where
+    toName NameBinding{ name = name₁ } = name₁
+
+    toNames PlainBinding{ plain } = [ toName plain ]
+    toNames RecordBinding{ fieldNames } = map toName fieldNames
+freeVariables List{ elements } =
+    Set.unions (fmap freeVariables elements)
+freeVariables Record{ fieldValues } = Set.unions (fmap onDefinition fieldValues)
+  where
+    onDefinition Definition{ bindings, assignment } =
+        Set.difference (freeVariables assignment) (Set.fromList (concatMap toNames bindings))
+
+    toName NameBinding{ name = name₁ } = name₁
+
+    toNames PlainBinding{ plain } = [ toName plain ]
+    toNames RecordBinding{ fieldNames } = map toName fieldNames
+freeVariables Project{ larger } =
+    freeVariables larger
+freeVariables Alternative{ argument } =
+    freeVariables argument
+freeVariables Fold{ handlers } =
+    freeVariables handlers
+freeVariables If{ predicate, ifTrue, ifFalse } =
+    Set.unions
+        ( [freeVariables predicate, freeVariables ifTrue, freeVariables ifFalse]
+        :: [Set Text]
+        )
+freeVariables Text{ chunks = Chunks _ pairs } =
+    Set.unions (fmap (freeVariables . fst) pairs)
+freeVariables Scalar{ } =
+    Set.empty
+freeVariables Prompt{ arguments } =
+    freeVariables arguments
+freeVariables HTTP{ arguments } =
+    freeVariables arguments
+freeVariables Read{ arguments } =
+    freeVariables arguments
+freeVariables GitHub{ arguments } =
+    freeVariables arguments
+freeVariables Show{ arguments } =
+    freeVariables arguments
+freeVariables Operator{ left, right } =
+    Set.union (freeVariables left) (freeVariables right)
+freeVariables Builtin{ } =
+    Set.empty
+freeVariables Embed{ } =
+    Set.empty
 
 -- | `Getting` that matches all effects within a `Syntax` tree
 effects :: Getting Any (Syntax s a) ()

--- a/tasty/data/complex/check-function-input.ffg
+++ b/tasty/data/complex/check-function-input.ffg
@@ -1,0 +1,1 @@
+fold { true: 0, false: 1 } : Bool -> Integer

--- a/tasty/data/complex/check-function-output.ffg
+++ b/tasty/data/complex/check-function-output.ffg
@@ -1,0 +1,1 @@
+\a -> fold { "true": 0, "false": 1 } a : Integer

--- a/tasty/data/complex/check-function-type.ffg
+++ b/tasty/data/complex/check-function-type.ffg
@@ -1,0 +1,1 @@
+Bool -> Integer

--- a/tasty/data/complex/examples-output.ffg
+++ b/tasty/data/complex/examples-output.ffg
@@ -141,24 +141,14 @@
     , "greeting":
         "Hello, world!"
     , "makeUser":
-        let greeting = "Hello, world!"
+        \{ user } ->
+          let home = "/home/${user}"
 
-        let greet = \{ name } -> "Hello, ${name}!"
+          let privateKey = "${home}/.ssh/id_ed25519"
 
-        in  \{ user } ->
-              let home = "/home/${user}"
+          let publicKey = "${privateKey}.pub"
 
-              let privateKey = "${home}/.ssh/id_ed25519"
-
-              let publicKey = "${privateKey}.pub"
-
-              in  { "home":
-                      home
-                  , "privateKey":
-                      privateKey
-                  , "publicKey":
-                      publicKey
-                  }
+          in  { "home": home, "privateKey": privateKey, "publicKey": publicKey }
     , "users":
         [ { "home":
               "/home/bill"

--- a/tasty/data/complex/subtype-function-output.ffg
+++ b/tasty/data/complex/subtype-function-output.ffg
@@ -1,1 +1,1 @@
-\x -> (\(x : Integer) -> x) (x : Integer)
+\a -> (\(x : Integer) -> x) (a : Integer)

--- a/tasty/data/error/type/fold-typo-field-stderr.txt
+++ b/tasty/data/error/type/fold-typo-field-stderr.txt
@@ -1,6 +1,6 @@
-Not a subtype
+Not a function type
 
-The following type:
+An expression of the following type:
 
   Natural
 
@@ -9,11 +9,5 @@ tasty/data/error/type/fold-typo-field-input.ffg:4:14:
 4 │ fold{ false: 0, tru: 1 }
   │              ↑
 
-… is not a subtype of:
-
-  b? -> a?
-
-tasty/data/error/type/fold-typo-field-input.ffg:4:1: 
-  │
-4 │ fold{ false: 0, tru: 1 }
-  │ ↑
+… was invoked as if it were a function, but the above type is not a function
+type.

--- a/tasty/data/error/type/impredicative-instantiation-stderr.txt
+++ b/tasty/data/error/type/impredicative-instantiation-stderr.txt
@@ -1,6 +1,6 @@
-Unbound type variable: c
+Unbound type variable: b
 
-tasty/data/error/type/impredicative-instantiation-input.ffg:6:62: 
+tasty/data/error/type/impredicative-instantiation-input.ffg:6:30: 
   │
 6 │ let g : (forall (b : Type) . b -> b) -> (forall (c : Type) . c -> c)
-  │                                                              ↑
+  │                              ↑

--- a/tasty/data/error/type/invalid-handler-stderr.txt
+++ b/tasty/data/error/type/invalid-handler-stderr.txt
@@ -1,6 +1,6 @@
-Not a subtype
+Not a function type
 
-The following type:
+An expression of the following type:
 
   Natural
 
@@ -9,11 +9,5 @@ tasty/data/error/type/invalid-handler-input.ffg:1:11:
 1 │ fold { x: 1 }
   │           ↑
 
-… is not a subtype of:
-
-  b? -> a?
-
-tasty/data/error/type/invalid-handler-input.ffg:1:1: 
-  │
-1 │ fold { x: 1 }
-  │ ↑
+… was invoked as if it were a function, but the above type is not a function
+type.


### PR DESCRIPTION
This is yet another step to remove the `subtype` judgment from the type checker and use `infer`/`check` to elaborate expressions instead.